### PR TITLE
Run yapf on Python files

### DIFF
--- a/DCGANs_object.py
+++ b/DCGANs_object.py
@@ -21,80 +21,104 @@ import matplotlib.pyplot as plt
 import GANs_abstract_object
 from GANs_abstract_object import *
 
+
 class DCGANs_model(GANs_model):
-    
     def __init__(self, data):
         super(DCGANs_model, self).__init__(data)
-        
+
     def build_discriminator(self):
         D = DiscriminativeCNN(self.data_dimension[0])
         D.apply(init_weights)
         return D
-    
-    def build_generator(self, noise_dimension = 100):
+
+    def build_generator(self, noise_dimension=100):
         self.noise_dimension = noise_dimension
         G = GenerativeCNN(noise_dimension, self.data_dimension[0])
         G.apply(init_weights)
         return G
-        
+
     # loss = torch.nn.BCEWithLogitsLoss()
     #loss = binary_cross_entropy
-    def train(self,loss = torch.nn.BCEWithLogitsLoss(), lr_x = torch.tensor([0.01]), lr_y = torch.tensor([0.01]), optimizer_name = 'Jacobi', num_epochs = 1, batch_size = 100, verbose = True, save_path = './data_fake_DCGANS',label_smoothing = False, single_number = None):
-        self.data_loader = torch.utils.data.DataLoader(self.data, batch_size=100, shuffle=True)
+    def train(self,
+              loss=torch.nn.BCEWithLogitsLoss(),
+              lr_x=torch.tensor([0.01]),
+              lr_y=torch.tensor([0.01]),
+              optimizer_name='Jacobi',
+              num_epochs=1,
+              batch_size=100,
+              verbose=True,
+              save_path='./data_fake_DCGANS',
+              label_smoothing=False,
+              single_number=None):
+        self.data_loader = torch.utils.data.DataLoader(
+            self.data, batch_size=100, shuffle=True)
         if single_number is not None:
             self.num_test_samples = 5
-            self.data = [i for i in self.data if i[1] == torch.tensor(single_number)]
-            self.data_loader = torch.utils.data.DataLoader(self.data, batch_size=100, shuffle=True)
+            self.data = [
+                i for i in self.data if i[1] == torch.tensor(single_number)
+            ]
+            self.data_loader = torch.utils.data.DataLoader(
+                self.data, batch_size=100, shuffle=True)
             self.display_progress = 50
-        else: 
-            self.data_loader = torch.utils.data.DataLoader(self.data, batch_size=100, shuffle=True)
+        else:
+            self.data_loader = torch.utils.data.DataLoader(
+                self.data, batch_size=100, shuffle=True)
             self.num_test_samples = 10
             self.display_progress = 100
 
-        self.verbose = verbose        
+        self.verbose = verbose
         self.save_path = save_path
         self.test_noise = noise(self.num_test_samples, self.noise_dimension)
-        self.optimizer_initialize(loss, lr_x, lr_y, optimizer_name, label_smoothing)     
+        self.optimizer_initialize(loss, lr_x, lr_y, optimizer_name,
+                                  label_smoothing)
         start = time.time()
         for e in range(num_epochs):
-            self.print_verbose("######################################################")
-            for n_batch, (real_batch,_) in enumerate(self.data_loader):
+            self.print_verbose(
+                "######################################################")
+            for n_batch, (real_batch, _) in enumerate(self.data_loader):
                 real_data = Variable((real_batch))
                 N = real_batch.size(0)
                 self.optimizer.zero_grad()
                 if optimizer_name == 'GaussSeidel':
-                    error_real, error_fake, g_error = self.optimizer.step(real_data,N)
+                    error_real, error_fake, g_error = self.optimizer.step(
+                        real_data, N)
                     self.D = optimizer.D
                     self.G = optimizer.G
                 else:
-                    error_real, error_fake, g_error, p_x, p_y = self.optimizer.step(real_data,N)
-                
+                    error_real, error_fake, g_error, p_x, p_y = self.optimizer.step(
+                        real_data, N)
+
                     index = 0
                     for p in self.G.parameters():
-                        p.data.add_(p_x[index: index + p.numel()].reshape(p.shape))
+                        p.data.add_(p_x[index:index + p.numel()].reshape(
+                            p.shape))
                         index += p.numel()
                     if index != p_x.numel():
                         raise RuntimeError('CG size mismatch')
                     index = 0
                     for p in self.D.parameters():
-                        p.data.add_(p_y[index: index + p.numel()].reshape(p.shape))
+                        p.data.add_(p_y[index:index + p.numel()].reshape(
+                            p.shape))
                         index += p.numel()
                     if index != p_y.numel():
                         raise RuntimeError('CG size mismatch')
-            
+
                 self.D_error_real_history.append(error_real)
                 self.D_error_fake_history.append(error_fake)
                 self.G_error_history.append(g_error)
-                
-                self.print_verbose('Epoch: ',str(e + 1 ) ,'/',str(num_epochs))
+
+                self.print_verbose('Epoch: ', str(e + 1), '/', str(num_epochs))
                 self.print_verbose('Batch Number: ', str(n_batch + 1))
-                self.print_verbose('Error_discriminator__real: ', "{:.5e}".format(error_real), 'Error_discriminator__fake: ', "{:.5e}".format(error_fake),'Error_generator: ', "{:.5e}".format(g_error))
-                
+                self.print_verbose(
+                    'Error_discriminator__real: ', "{:.5e}".format(error_real),
+                    'Error_discriminator__fake: ', "{:.5e}".format(error_fake),
+                    'Error_generator: ', "{:.5e}".format(g_error))
+
                 if (n_batch) % self.display_progress == 0:
                     test_images = self.optimizer.G(self.test_noise)
-                    self.save_images(e, n_batch, test_images)      
-                        
-            self.print_verbose("######################################################")
-        end = time.time()
-        self.print_verbose('Total Time[s]: ', str( end - start))
+                    self.save_images(e, n_batch, test_images)
 
+            self.print_verbose(
+                "######################################################")
+        end = time.time()
+        self.print_verbose('Total Time[s]: ', str(end - start))

--- a/Dataloader.py
+++ b/Dataloader.py
@@ -15,58 +15,64 @@ from torch.autograd.variable import Variable
 from torchvision import transforms, datasets
 import matplotlib.pyplot as plt
 import os
+
 #from utils import Logger
 
-def mnist_data(rand_rotation = False, max_degree = 90):
+
+def mnist_data(rand_rotation=False, max_degree=90):
     if rand_rotation == True:
-        compose = transforms.Compose([transforms.RandomRotation(max_degree),
-                                  transforms.ToTensor(),
-                                  transforms.Normalize((0.5,), (0.5,))
-                                  ])
-    else:
         compose = transforms.Compose([
-                                      transforms.ToTensor(),
-                                      transforms.Normalize((0.5,), (0.5,))
-                                      ])
-        
+            transforms.RandomRotation(max_degree),
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, ), (0.5, ))
+        ])
+    else:
+        compose = transforms.Compose(
+            [transforms.ToTensor(),
+             transforms.Normalize((0.5, ), (0.5, ))])
+
     out_dir = './dataset'
-    return datasets.MNIST(root=out_dir, train=True, transform=compose, download=True)
+    return datasets.MNIST(
+        root=out_dir, train=True, transform=compose, download=True)
+
 
 def cifar10_data():
 
-    compose = transforms.Compose([transforms.ToTensor(), 
-                                              transforms.Normalize((.5,.5,.5), (.5,.5,.5))
-                                              ])
+    compose = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((.5, .5, .5), (.5, .5, .5))
+    ])
     out_dir = './dataset'
-    return datasets.CIFAR10(root=out_dir, train=True, transform=compose, download=True)
+    return datasets.CIFAR10(
+        root=out_dir, train=True, transform=compose, download=True)
 
-def mnist_data_dcgans(rand_rotation = False, max_degree = 90):
+
+def mnist_data_dcgans(rand_rotation=False, max_degree=90):
     if rand_rotation == True:
-        compose = transforms.Compose(
-                [
-                        transforms.Resize(64),
-                        transforms.RandomRotation(max_degree),
-                        transforms.ToTensor(),
-                        transforms.Normalize((0.5,), (0.5,))
-                        ])
-        
+        compose = transforms.Compose([
+            transforms.Resize(64),
+            transforms.RandomRotation(max_degree),
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, ), (0.5, ))
+        ])
+
     else:
-        compose = transforms.Compose(
-                [
-                        transforms.Resize(64),
-                        transforms.ToTensor(),
-                        transforms.Normalize((0.5,), (0.5,))
-                        ])
+        compose = transforms.Compose([
+            transforms.Resize(64),
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, ), (0.5, ))
+        ])
     out_dir = '{}/dataset'.format(os.getcwd())
-    return datasets.MNIST(root=out_dir, train=True, transform=compose, download=True)
+    return datasets.MNIST(
+        root=out_dir, train=True, transform=compose, download=True)
 
 
 def cifar_data_dcgans():
-    compose = transforms.Compose(
-        [
-            transforms.Resize(64),
-            transforms.ToTensor(),
-            transforms.Normalize((.5,.5,.5), (.5,.5,.5))
-        ])
+    compose = transforms.Compose([
+        transforms.Resize(64),
+        transforms.ToTensor(),
+        transforms.Normalize((.5, .5, .5), (.5, .5, .5))
+    ])
     out_dir = '{}/dataset'.format(os.getcwd())
-    return datasets.CIFAR10(root=out_dir, train=True, transform=compose, download=True)
+    return datasets.CIFAR10(
+        root=out_dir, train=True, transform=compose, download=True)

--- a/GANs_abstract_object.py
+++ b/GANs_abstract_object.py
@@ -23,7 +23,6 @@ from abc import ABCMeta, abstractmethod
 
 
 class GANs_model(object):
-    
     def __init__(self, data):
         self.data = data
         self.data_dimension = self.data[0][0].numpy().shape
@@ -31,22 +30,22 @@ class GANs_model(object):
         self.D_error_real_history = []
         self.D_error_fake_history = []
         self.G_error_history = []
-        
+
         if self.data_dimension[0] == 3:
             self.imtype = 'RGB'
         else:
             self.imtype = 'gray'
-            
+
     def print_verbose(self, *args, **kwargs):
-        if self.verbose :
+        if self.verbose:
             print(*args, **kwargs)
-            
-    def createFolder(self,directory):
+
+    def createFolder(self, directory):
         try:
             if not os.path.exists(directory):
                 os.makedirs(directory)
         except OSError:
-            print ('Error: Creating directory. ' +  directory)
+            print('Error: Creating directory. ' + directory)
 
     def save_models(self):
         #G_directory = self.createFolder("/G_model")
@@ -69,9 +68,15 @@ class GANs_model(object):
     def build_generator(self):
         pass
 
-    def optimizer_initialize(self, loss, lr_x, lr_y, optimizer_name='SGD', label_smoothing=False):    
+    def optimizer_initialize(self,
+                             loss,
+                             lr_x,
+                             lr_y,
+                             optimizer_name='SGD',
+                             label_smoothing=False):
         if optimizer_name == 'Jacobi':
-            self.optimizer = Jacobi(self.G, self.D, loss, lr_x, lr_y, label_smoothing)
+            self.optimizer = Jacobi(self.G, self.D, loss, lr_x, lr_y,
+                                    label_smoothing)
         elif optimizer_name == 'CGD':
             self.optimizer = CGD(self.G, self.D, loss, lr_x)
         elif optimizer_name == 'Newton':
@@ -82,33 +87,42 @@ class GANs_model(object):
             self.optimizer = GaussSeidel(self.G, self.D, loss, lr_x, lr_y)
         else:
             self.optimizer = SGD(self.G, self.D, loss, lr_x)
-            
+
     def save_images(self, epoch_number, n_batch, images):
         count = 0
-        for image_index in range(0,images.shape[0]):
+        for image_index in range(0, images.shape[0]):
             count = count + 1
             if self.imtype == 'RGB':
-                image = images[image_index]#[0]
+                image = images[image_index]  #[0]
                 image = image.detach().numpy()
-                image = (image + 1)/2
+                image = (image + 1) / 2
                 image = image.transpose([1, 2, 0])
                 self.createFolder(self.save_path)
-                path = str(self.save_path + '/fake_image'+'_Epoch_'+str(e + 1)+'_Batch_'+str(n_batch)+'_N_image_'+str(count)+'.png')
+                path = str(self.save_path + '/fake_image' + '_Epoch_' +
+                           str(e + 1) + '_Batch_' + str(n_batch) +
+                           '_N_image_' + str(count) + '.png')
                 plt.imsave(path, image)
             else:
                 image = images[image_index][0]
                 image = image.detach().numpy()
-                image = (image + 1)/2
-                img = pil.fromarray(np.uint8(image * 255) , 'L')
+                image = (image + 1) / 2
+                img = pil.fromarray(np.uint8(image * 255), 'L')
                 self.createFolder(self.save_path)
-                path = str(self.save_path + '/fake_image'+'_Epoch_'+str(epoch_number + 1)+'_Batch_'+str(n_batch)+'_N_image_'+str(count)+'.png')
+                path = str(self.save_path + '/fake_image' + '_Epoch_' +
+                           str(epoch_number + 1) + '_Batch_' + str(n_batch) +
+                           '_N_image_' + str(count) + '.png')
                 img.save(path)
-        
-    
+
     @abstractmethod
-    def train(self,loss = torch.nn.BCEWithLogitsLoss(), lr_x = torch.tensor([0.001]), lr_y = torch.tensor([0.001]), optimizer_name = 'Jacobi', num_epochs = 1, 
-               batch_size = 100, verbose = True, save_path = './data_fake', label_smoothing = False, single_number = None):
+    def train(self,
+              loss=torch.nn.BCEWithLogitsLoss(),
+              lr_x=torch.tensor([0.001]),
+              lr_y=torch.tensor([0.001]),
+              optimizer_name='Jacobi',
+              num_epochs=1,
+              batch_size=100,
+              verbose=True,
+              save_path='./data_fake',
+              label_smoothing=False,
+              single_number=None):
         pass
-    
-
-

--- a/MLP_GANs_object.py
+++ b/MLP_GANs_object.py
@@ -22,82 +22,106 @@ import matplotlib.pyplot as plt
 import GANs_abstract_object
 from GANs_abstract_object import *
 
+
 class MLP_GANs_model(GANs_model):
-    
     def __init__(self, data):
         super(MLP_GANs_model, self).__init__(data)
-                    
+
     def build_discriminator(self):
         n_features = numpy.prod(self.data_dimension)
         D = Discriminator(n_features)
         return D
-    
-    def build_generator(self, noise_dimension = 100):
+
+    def build_generator(self, noise_dimension=100):
         self.noise_dimension = noise_dimension
         n_out = numpy.prod(self.data_dimension)
         G = Generator(noise_dimension, n_out)
         return G
-    
+
     # loss = torch.nn.BCEWithLogitsLoss()
     # loss = binary_cross_entropy
-    def train(self,loss = torch.nn.BCEWithLogitsLoss(), lr_x = torch.tensor([0.001]), lr_y = torch.tensor([0.001]), optimizer_name = 'SGD', num_epochs = 1, 
-               batch_size = 100, verbose = True, save_path = './data_fake', label_smoothing = False, single_number = None):
+    def train(self,
+              loss=torch.nn.BCEWithLogitsLoss(),
+              lr_x=torch.tensor([0.001]),
+              lr_y=torch.tensor([0.001]),
+              optimizer_name='SGD',
+              num_epochs=1,
+              batch_size=100,
+              verbose=True,
+              save_path='./data_fake',
+              label_smoothing=False,
+              single_number=None):
         if single_number is not None:
-            self.data = [i for i in self.data if i[1] == torch.tensor(single_number)]
-            self.data_loader = torch.utils.data.DataLoader(self.data, batch_size=100, shuffle=True)
+            self.data = [
+                i for i in self.data if i[1] == torch.tensor(single_number)
+            ]
+            self.data_loader = torch.utils.data.DataLoader(
+                self.data, batch_size=100, shuffle=True)
             self.num_test_samples = 5
             self.display_progress = 50
-        else: 
-            self.data_loader = torch.utils.data.DataLoader(self.data, batch_size=100, shuffle=True)
+        else:
+            self.data_loader = torch.utils.data.DataLoader(
+                self.data, batch_size=100, shuffle=True)
             self.num_test_samples = 16
             self.display_progress = 100
 
-        self.verbose = verbose        
+        self.verbose = verbose
         self.save_path = save_path
         self.test_noise = noise(self.num_test_samples, self.noise_dimension)
-        self.optimizer_initialize(loss, lr_x, lr_y, optimizer_name, label_smoothing)     
+        self.optimizer_initialize(loss, lr_x, lr_y, optimizer_name,
+                                  label_smoothing)
         start = time.time()
         for e in range(num_epochs):
-            self.print_verbose("######################################################")
-            for n_batch, (real_batch,_) in enumerate(self.data_loader):
+            self.print_verbose(
+                "######################################################")
+            for n_batch, (real_batch, _) in enumerate(self.data_loader):
                 N = real_batch.size(0)
                 real_data = Variable(images_to_vectors(real_batch))
                 self.optimizer.G = self.G
                 self.optimizer.D = self.D
                 self.optimizer.zero_grad()
-                
+
                 if optimizer_name == 'GaussSeidel':
-                    error_real, error_fake, g_error = self.optimizer.step(real_data,N)
+                    error_real, error_fake, g_error = self.optimizer.step(
+                        real_data, N)
                     self.D = self.optimizer.D
                     self.G = self.optimizer.G
                 else:
-                    error_real, error_fake, g_error, p_x, p_y = self.optimizer.step(real_data,N)
+                    error_real, error_fake, g_error, p_x, p_y = self.optimizer.step(
+                        real_data, N)
                     index = 0
                     for p in self.G.parameters():
-                        p.data.add_(p_x[index: index + p.numel()].reshape(p.shape))
+                        p.data.add_(p_x[index:index + p.numel()].reshape(
+                            p.shape))
                         index += p.numel()
                     if index != p_x.numel():
                         raise RuntimeError('CG size mismatch')
                     index = 0
                     for p in self.D.parameters():
-                        p.data.add_(p_y[index: index + p.numel()].reshape(p.shape))
+                        p.data.add_(p_y[index:index + p.numel()].reshape(
+                            p.shape))
                         index += p.numel()
                     if index != p_y.numel():
                         raise RuntimeError('CG size mismatch')
-                
+
                 self.D_error_real_history.append(error_real)
                 self.D_error_fake_history.append(error_fake)
                 self.G_error_history.append(g_error)
-                
-                self.print_verbose('Epoch: ',str(e + 1 ) ,'/',str(num_epochs))
-                self.print_verbose('Batch Number: ', str(n_batch + 1))
-                self.print_verbose('Error_discriminator__real: ', "{:.5e}".format(error_real), 'Error_discriminator__fake: ', "{:.5e}".format(error_fake),'Error_generator: ', "{:.5e}".format(g_error))
-                
-                if (n_batch) % self.display_progress == 0:    
-                    test_images = vectors_to_images(self.G(self.test_noise), self.data_dimension) # data_dimension: dimension of output image ex: [1,28,28]
-                    self.save_images(e, n_batch, test_images)                                                                                  
-                        
-            self.print_verbose("######################################################")
-        end = time.time()
-        self.print_verbose('Total Time[s]: ', str( end - start))
 
+                self.print_verbose('Epoch: ', str(e + 1), '/', str(num_epochs))
+                self.print_verbose('Batch Number: ', str(n_batch + 1))
+                self.print_verbose(
+                    'Error_discriminator__real: ', "{:.5e}".format(error_real),
+                    'Error_discriminator__fake: ', "{:.5e}".format(error_fake),
+                    'Error_generator: ', "{:.5e}".format(g_error))
+
+                if (n_batch) % self.display_progress == 0:
+                    test_images = vectors_to_images(
+                        self.G(self.test_noise), self.data_dimension
+                    )  # data_dimension: dimension of output image ex: [1,28,28]
+                    self.save_images(e, n_batch, test_images)
+
+            self.print_verbose(
+                "######################################################")
+        end = time.time()
+        self.print_verbose('Total Time[s]: ', str(end - start))

--- a/main_GANs.py
+++ b/main_GANs.py
@@ -9,8 +9,6 @@
 
 from MLP_GANs_object import *
 from DCGANs_object import *
-
-
 '''
 ! READ ME !
 
@@ -34,23 +32,27 @@ TO TRY: Setting much lower learning rates to see if model collapse is avoided (e
 
 '''
 
-
 #model = MLP_GANs_model(mnist_data(rand_rotation = False, max_degree = 90))
-#model.train(num_epochs = 200, lr_x = torch.tensor([0.01]), lr_y = torch.tensor([0.01]), 
+#model.train(num_epochs = 200, lr_x = torch.tensor([0.01]), lr_y = torch.tensor([0.01]),
 #            optimizer_name = 'CGD', verbose = True, label_smoothing = False, single_number = 4) # save_path = ''
 
-
 #model = DCGANs_model(mnist_data_dcgans(rand_rotation = False, max_degree = 90))
-#model.train(num_epochs = 1, lr_x = torch.tensor([0.01]), lr_y = torch.tensor([0.01]), 
+#model.train(num_epochs = 1, lr_x = torch.tensor([0.01]), lr_y = torch.tensor([0.01]),
 #           optimizer_name = 'Jacobi', verbose = True, label_smoothing = False, single_number = 9) #save_path = ''
 
 #model.save_models()
 
 plt.figure()
-plt.plot([x for x in range(0,len(model.D_error_real_history))], model.D_error_real_history)
-plt.plot([x for x in range(0,len(model.D_error_fake_history))], model.D_error_fake_history)
-plt.plot([x for x in range(0,len(model.G_error_history))], model.G_error_history)
+plt.plot([x for x in range(0, len(model.D_error_real_history))],
+         model.D_error_real_history)
+plt.plot([x for x in range(0, len(model.D_error_fake_history))],
+         model.D_error_fake_history)
+plt.plot([x for x in range(0, len(model.G_error_history))],
+         model.G_error_history)
 plt.xlabel('Iterations')
 plt.ylabel('Loss function value')
-plt.legend(['Discriminator: Loss on Real Data', 'Discriminator: Loss on Fake Data', 'Generator: Loss'])
+plt.legend([
+    'Discriminator: Loss on Real Data', 'Discriminator: Loss on Fake Data',
+    'Generator: Loss'
+])
 plt.savefig('cost_report.png')

--- a/main_GANs.py
+++ b/main_GANs.py
@@ -25,7 +25,7 @@ Label smoothing variation is implemented only for optimizer 'Jacobi' and only fo
 
 To swich from MLP_GANs (DCGANs) to DCGANs (MLP_GANs) comment lines 38,39,40 (43,44,45) and uncomment 43,44,45 (38,39,40)
 
-Attribute save_models of both training object saves the state dicts of the networks into 2 different folders 
+Attribute save_models of both training object saves the state dicts of the networks into 2 different folders
 inside your current directory
 
 TO TRY: Setting much lower learning rates to see if model collapse is avoided (ex. lr_x = 0.0001 , lr_y = 0.0004)

--- a/models.py
+++ b/models.py
@@ -10,39 +10,31 @@ Created on Tue Mar 17 11:26:08 2020
 """
 import torch
 import torch.nn as nn
-    
+
+
 class Discriminator(nn.Module):
     def __init__(self, n_features):
         super(Discriminator, self).__init__()
-        self.hidden0 = nn.Sequential(nn.Linear(n_features, 250),
-                                     nn.ReLU())
-        self.hidden1 = nn.Sequential(nn.Linear(250,100),
-                                     nn.ReLU())
-        self.out = nn.Sequential(nn.Linear(100,1),
-                                 nn.Sigmoid())
+        self.hidden0 = nn.Sequential(nn.Linear(n_features, 250), nn.ReLU())
+        self.hidden1 = nn.Sequential(nn.Linear(250, 100), nn.ReLU())
+        self.out = nn.Sequential(nn.Linear(100, 1), nn.Sigmoid())
+
     def forward(self, input):
         x = self.hidden0(input)
         y = self.hidden1(x)
         z = self.out(y)
         return z
-    
+
+
 class Generator(torch.nn.Module):
-    
-    def __init__(self,noise_dimension, n_out):
-        super(Generator, self).__init__()  
+    def __init__(self, noise_dimension, n_out):
+        super(Generator, self).__init__()
         self.hidden0 = nn.Sequential(
             nn.Linear(noise_dimension, 1000),
-            nn.ReLU())                      #  ORIGINAL:   nn.LeakyReLU(0.2))
-        self.hidden1 = nn.Sequential(
-                nn.Linear(1000,1000),
-                nn.ReLU())
-        self.hidden2 = nn.Sequential(
-                nn.Linear(1000,1000),
-                nn.ReLU())
-        self.out = nn.Sequential(
-            nn.Linear(1000, n_out),
-            nn.Tanh()
-        )
+            nn.ReLU())  #  ORIGINAL:   nn.LeakyReLU(0.2))
+        self.hidden1 = nn.Sequential(nn.Linear(1000, 1000), nn.ReLU())
+        self.hidden2 = nn.Sequential(nn.Linear(1000, 1000), nn.ReLU())
+        self.out = nn.Sequential(nn.Linear(1000, n_out), nn.Tanh())
 
     def forward(self, input):
         x = self.hidden0(input)
@@ -50,45 +42,49 @@ class Generator(torch.nn.Module):
         w = self.hidden2(y)
         z = self.out(w)
         return z
-    
-    
+
+
 class DiscriminativeCNN(torch.nn.Module):
     def __init__(self, n_channels):
         super(DiscriminativeCNN, self).__init__()
-        
+
         self.conv1 = nn.Sequential(
             nn.Conv2d(
-                in_channels=n_channels, out_channels=128, kernel_size=4, 
-                stride=2, padding=1, bias=False
-            ),
-            nn.LeakyReLU(0.2, inplace=True)
-        )
+                in_channels=n_channels,
+                out_channels=128,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False), nn.LeakyReLU(0.2, inplace=True))
         self.conv2 = nn.Sequential(
             nn.Conv2d(
-                in_channels=128, out_channels=256, kernel_size=4,
-                stride=2, padding=1, bias=False
-            ),
-            nn.BatchNorm2d(256),
-            nn.LeakyReLU(0.2, inplace=True)
-        )
+                in_channels=128,
+                out_channels=256,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False), nn.BatchNorm2d(256),
+            nn.LeakyReLU(0.2, inplace=True))
         self.conv3 = nn.Sequential(
             nn.Conv2d(
-                in_channels=256, out_channels=512, kernel_size=4,
-                stride=2, padding=1, bias=False
-            ),
-            nn.BatchNorm2d(512),
-            nn.LeakyReLU(0.2, inplace=True)
-        )
+                in_channels=256,
+                out_channels=512,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False), nn.BatchNorm2d(512),
+            nn.LeakyReLU(0.2, inplace=True))
         self.conv4 = nn.Sequential(
             nn.Conv2d(
-                in_channels=512, out_channels=1024, kernel_size=4,
-                stride=2, padding=1, bias=False
-            ),
-            nn.BatchNorm2d(1024),
-            nn.LeakyReLU(0.2, inplace=True)
-        )
+                in_channels=512,
+                out_channels=1024,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False), nn.BatchNorm2d(1024),
+            nn.LeakyReLU(0.2, inplace=True))
         self.out = nn.Sequential(
-            nn.Linear(1024*4*4, 1),
+            nn.Linear(1024 * 4 * 4, 1),
             nn.Sigmoid(),
         )
 
@@ -99,48 +95,55 @@ class DiscriminativeCNN(torch.nn.Module):
         x = self.conv3(x)
         x = self.conv4(x)
         # Flatten and apply sigmoid
-        x = x.view(-1, 1024*4*4)
+        x = x.view(-1, 1024 * 4 * 4)
         x = self.out(x)
         return x
 
 
 class GenerativeCNN(torch.nn.Module):
-    
     def __init__(self, noise_dimension, n_channels):
         super(GenerativeCNN, self).__init__()
-        
-        self.linear = torch.nn.Linear(noise_dimension, 1024*4*4)
-        
+
+        self.linear = torch.nn.Linear(noise_dimension, 1024 * 4 * 4)
+
         self.conv1 = nn.Sequential(
             nn.ConvTranspose2d(
-                in_channels=1024, out_channels=512, kernel_size=4,
-                stride=2, padding=1, bias=False
-            ),
+                in_channels=1024,
+                out_channels=512,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False),
             nn.BatchNorm2d(512),
-            nn.ReLU(inplace=True)
-        )
+            nn.ReLU(inplace=True))
         self.conv2 = nn.Sequential(
             nn.ConvTranspose2d(
-                in_channels=512, out_channels=256, kernel_size=4,
-                stride=2, padding=1, bias=False
-            ),
+                in_channels=512,
+                out_channels=256,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False),
             nn.BatchNorm2d(256),
-            nn.ReLU(inplace=True)
-        )
+            nn.ReLU(inplace=True))
         self.conv3 = nn.Sequential(
             nn.ConvTranspose2d(
-                in_channels=256, out_channels=128, kernel_size=4,
-                stride=2, padding=1, bias=False
-            ),
+                in_channels=256,
+                out_channels=128,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False),
             nn.BatchNorm2d(128),
-            nn.ReLU(inplace=True)
-        )
+            nn.ReLU(inplace=True))
         self.conv4 = nn.Sequential(
             nn.ConvTranspose2d(
-                in_channels=128, out_channels=n_channels, kernel_size=4,
-                stride=2, padding=1, bias=False
-            )
-        )
+                in_channels=128,
+                out_channels=n_channels,
+                kernel_size=4,
+                stride=2,
+                padding=1,
+                bias=False))
         self.out = torch.nn.Tanh()
 
     def forward(self, x):
@@ -154,4 +157,3 @@ class GenerativeCNN(torch.nn.Module):
         x = self.conv4(x)
         # Apply Tanh
         return self.out(x)
-    

--- a/optimizers.py
+++ b/optimizers.py
@@ -27,70 +27,95 @@ from abc import ABCMeta, abstractmethod
 
 
 class Optimizer(object, metaclass=ABCMeta):
-    
     def __init__(self, G, D, criterion):
         self.count = 0
         self.criterion = criterion
         self.D = D
-        self.G = G    
-        
+        self.G = G
+
     def zero_grad(self):
         zero_grad(self.G.parameters())
-        zero_grad(self.D.parameters())        
-    
+        zero_grad(self.D.parameters())
+
     @abstractmethod
     def step(self, real_data, N):
         pass
 
 
-class CGD(Optimizer): 
-    
-    def __init__(self, G, D, criterion,lr=1e-3):
+class CGD(Optimizer):
+    def __init__(self, G, D, criterion, lr=1e-3):
         super(CGD, self).__init__(G, D, criterion)
         self.lr = lr
-                
-    def step(self,real_data, N):
+
+    def step(self, real_data, N):
         fake_data = self.G(noise(N, 100))
         prediction_real = self.D(real_data)
-        error_real = self.criterion(prediction_real, ones_target(N) )
+        error_real = self.criterion(prediction_real, ones_target(N))
         prediction_fake = self.D(fake_data)
         error_fake = self.criterion(prediction_fake, zeros_target(N))
         error_tot = error_fake + error_real
         errorG = self.criterion(prediction_fake, ones_target(N))
-        grad_x = autograd.grad(error_tot, self.G.parameters(), create_graph=True, retain_graph=True, allow_unused= True)
+        grad_x = autograd.grad(
+            error_tot,
+            self.G.parameters(),
+            create_graph=True,
+            retain_graph=True,
+            allow_unused=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        grad_y = autograd.grad(error_tot, self.D.parameters(), create_graph=True, retain_graph=True)
+        grad_y = autograd.grad(
+            error_tot,
+            self.D.parameters(),
+            create_graph=True,
+            retain_graph=True)
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
-        scaled_grad_x = torch.mul(self.lr,grad_x_vec)
-        scaled_grad_y = torch.mul(self.lr,grad_y_vec)
+        scaled_grad_x = torch.mul(self.lr, grad_x_vec)
+        scaled_grad_y = torch.mul(self.lr, grad_y_vec)
         #l = autograd.grad(grad_x_vec, discriminator.parameters(), grad_outputs = torch.ones_like(grad_x_vec))
-        
-        hvp_x_vec = Hvp_vec(grad_y_vec, self.G.parameters(), scaled_grad_y,retain_graph=True)  # D_xy * lr_y * grad_y 
-        hvp_y_vec = Hvp_vec(grad_x_vec, self.D.parameters(), scaled_grad_x,retain_graph=True)  # D_yx * lr_x * grad_x
-        p_x = torch.add(grad_x_vec, - hvp_x_vec).detach_()  # grad_x - D_xy * lr_y * grad_y
-        p_y = torch.add(grad_y_vec, hvp_y_vec).detach_()  # grad_y + D_yx * lr_x * grad_x
+
+        hvp_x_vec = Hvp_vec(
+            grad_y_vec, self.G.parameters(), scaled_grad_y,
+            retain_graph=True)  # D_xy * lr_y * grad_y
+        hvp_y_vec = Hvp_vec(
+            grad_x_vec, self.D.parameters(), scaled_grad_x,
+            retain_graph=True)  # D_yx * lr_x * grad_x
+        p_x = torch.add(grad_x_vec,
+                        -hvp_x_vec).detach_()  # grad_x - D_xy * lr_y * grad_y
+        p_y = torch.add(grad_y_vec,
+                        hvp_y_vec).detach_()  # grad_y + D_yx * lr_x * grad_x
         p_x.mul_(self.lr.sqrt())
-        cg_x, iter_num = general_conjugate_gradient(grad_x=grad_x_vec, grad_y=grad_y_vec,
-                                                             x_params=self.G.parameters(),
-                                                             y_params=self.D.parameters(), kk=p_x,
-                                                             x=None,
-                                                             nsteps=p_x.shape[0],
-                                                             lr_x=self.lr, lr_y=self.lr,
-                                                             )
-            # cg_x.detach_().mul_(p_x_norm)
-            # cg_x.detach_().mul_(p_x_norm)
+        cg_x, iter_num = general_conjugate_gradient(
+            grad_x=grad_x_vec,
+            grad_y=grad_y_vec,
+            x_params=self.G.parameters(),
+            y_params=self.D.parameters(),
+            kk=p_x,
+            x=None,
+            nsteps=p_x.shape[0],
+            lr_x=self.lr,
+            lr_y=self.lr,
+        )
+        # cg_x.detach_().mul_(p_x_norm)
+        # cg_x.detach_().mul_(p_x_norm)
         cg_x.detach_().mul_(self.lr.sqrt())  # delta x = lr_x.sqrt() * cg_x
-        hcg = Hvp_vec(grad_x_vec, self.D.parameters(), cg_x, retain_graph=True).add_(grad_y_vec).detach_()
-                # grad_y + D_yx * delta x
-        cg_y = hcg.mul(- self.lr)
-        
+        hcg = Hvp_vec(
+            grad_x_vec, self.D.parameters(), cg_x,
+            retain_graph=True).add_(grad_y_vec).detach_()
+        # grad_y + D_yx * delta x
+        cg_y = hcg.mul(-self.lr)
+
         return error_real.item(), error_fake.item(), errorG.item(), cg_x, cg_y
-                
-            
-class CGD_shafer(Optimizer): 
-    
-    def __init__(self, G, D, criterion, eps=1e-8, beta2=0.99, lr=1e-3, solve_x = False):
-        super(CGD_shafer, self).__init__(G, D, criterion)     
+
+
+class CGD_shafer(Optimizer):
+    def __init__(self,
+                 G,
+                 D,
+                 criterion,
+                 eps=1e-8,
+                 beta2=0.99,
+                 lr=1e-3,
+                 solve_x=False):
+        super(CGD_shafer, self).__init__(G, D, criterion)
         self.G_params = list(G.parameters())
         self.D_params = list(D.parameters())
         self.lr = lr
@@ -99,66 +124,83 @@ class CGD_shafer(Optimizer):
         self.beta2 = beta2
         self.eps = eps
         self.cg_x = None
-        self.cg_y = None  
+        self.cg_y = None
         self.count = 0
         self.old_x = None
         self.old_y = None
         self.solve_x = solve_x
 
-    def step(self,real_data, N):
+    def step(self, real_data, N):
         self.count += 1
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         d_pred_real = self.D(real_data)
-        error_real = self.criterion(d_pred_real, ones_target(N) )
+        error_real = self.criterion(d_pred_real, ones_target(N))
         d_pred_fake = self.D(fake_data)
         error_fake = self.criterion(d_pred_fake, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
         loss = error_fake + error_real
-        grad_x = autograd.grad(loss, self.G_params, create_graph=True,
-                               retain_graph=True)
+        grad_x = autograd.grad(
+            loss, self.G_params, create_graph=True, retain_graph=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        grad_y = autograd.grad(loss, self.D_params, create_graph=True,
-                               retain_graph=True)
+        grad_y = autograd.grad(
+            loss, self.D_params, create_graph=True, retain_graph=True)
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
 
         if self.square_avgx is None and self.square_avgy is None:
-            self.square_avgx = torch.zeros(grad_x_vec.size(), requires_grad=False)
-            self.square_avgy = torch.zeros(grad_y_vec.size(), requires_grad=False)
-        self.square_avgx.mul_(self.beta2).addcmul_(1 - self.beta2, grad_x_vec.data, grad_x_vec.data)
-        self.square_avgy.mul_(self.beta2).addcmul_(1 - self.beta2, grad_y_vec.data, grad_y_vec.data)
+            self.square_avgx = torch.zeros(
+                grad_x_vec.size(), requires_grad=False)
+            self.square_avgy = torch.zeros(
+                grad_y_vec.size(), requires_grad=False)
+        self.square_avgx.mul_(self.beta2).addcmul_(
+            1 - self.beta2, grad_x_vec.data, grad_x_vec.data)
+        self.square_avgy.mul_(self.beta2).addcmul_(
+            1 - self.beta2, grad_y_vec.data, grad_y_vec.data)
 
         # Initialization bias correction
-        bias_correction2 = 1 - self.beta2 ** self.count
+        bias_correction2 = 1 - self.beta2**self.count
 
-        lr_x = math.sqrt(bias_correction2) * self.lr / self.square_avgx.sqrt().add(self.eps)
-        lr_y = math.sqrt(bias_correction2) * self.lr / self.square_avgy.sqrt().add(self.eps)
-        
+        lr_x = math.sqrt(bias_correction2) * self.lr / self.square_avgx.sqrt(
+        ).add(self.eps)
+        lr_y = math.sqrt(bias_correction2) * self.lr / self.square_avgy.sqrt(
+        ).add(self.eps)
+
         scaled_grad_x = torch.mul(lr_x, grad_x_vec).detach()  # lr_x * grad_x
         scaled_grad_y = torch.mul(lr_y, grad_y_vec).detach()  # lr_y * grad_y
-        
-        hvp_x_vec = Hvp_vec(grad_y_vec, self.G_params, scaled_grad_y,
-                           retain_graph=True)  # D_xy * lr_y * grad_y
-        hvp_y_vec = Hvp_vec(grad_x_vec, self.D_params, scaled_grad_x,
-                           retain_graph=True)  # D_yx * lr_x * grad_x
 
-        p_x = torch.add(grad_x_vec, - hvp_x_vec).detach_()  # grad_x - D_xy * lr_y * grad_y
-        p_y = torch.add(grad_y_vec, hvp_y_vec).detach_()  # grad_y + D_yx * lr_x * grad_x
-        
+        hvp_x_vec = Hvp_vec(
+            grad_y_vec, self.G_params, scaled_grad_y,
+            retain_graph=True)  # D_xy * lr_y * grad_y
+        hvp_y_vec = Hvp_vec(
+            grad_x_vec, self.D_params, scaled_grad_x,
+            retain_graph=True)  # D_yx * lr_x * grad_x
+
+        p_x = torch.add(grad_x_vec,
+                        -hvp_x_vec).detach_()  # grad_x - D_xy * lr_y * grad_y
+        p_y = torch.add(grad_y_vec,
+                        hvp_y_vec).detach_()  # grad_y + D_yx * lr_x * grad_x
+
         if self.solve_x:
             p_y.mul_(lr_y.sqrt())
             # p_y_norm = p_y.norm(p=2).detach_()
             # if self.old_y is not None:
             #     self.old_y = self.old_y / p_y_norm
-            cg_y, self.iter_num = general_conjugate_gradient(grad_x=grad_y_vec, grad_y=grad_x_vec,
-                                                             x_params=self.D_params,
-                                                             y_params=self.G_params, kk=p_y,
-                                                             x=self.old_y,
-                                                             nsteps=p_y.shape[0] // 10000,
-                                                             lr_x=lr_y, lr_y=lr_x)
+            cg_y, self.iter_num = general_conjugate_gradient(
+                grad_x=grad_y_vec,
+                grad_y=grad_x_vec,
+                x_params=self.D_params,
+                y_params=self.G_params,
+                kk=p_y,
+                x=self.old_y,
+                nsteps=p_y.shape[0] // 10000,
+                lr_x=lr_y,
+                lr_y=lr_x)
             # cg_y.mul_(p_y_norm)
-            cg_y.detach_().mul_(- lr_y.sqrt())
-            hcg = Hvp_vec(grad_y_vec, self.G_params, cg_y, retain_graph=True).add_(
-                grad_x_vec).detach_()
+            cg_y.detach_().mul_(-lr_y.sqrt())
+            hcg = Hvp_vec(
+                grad_y_vec, self.G_params, cg_y,
+                retain_graph=True).add_(grad_x_vec).detach_()
             # grad_x + D_xy * delta y
             cg_x = hcg.mul(lr_x)
             self.old_x = hcg.mul(lr_x.sqrt())
@@ -168,42 +210,56 @@ class CGD_shafer(Optimizer):
             # p_x_norm = p_x.norm(p=2).detach_()
             # if self.old_x is not None:
             #     self.old_x = self.old_x / p_x_norm
-            cg_x, self.iter_num = general_conjugate_gradient(grad_x=grad_x_vec, grad_y=grad_y_vec,
-                                                             x_params=self.G_params,
-                                                             y_params=self.D_params, kk=p_x,
-                                                             x=self.old_x,
-                                                             nsteps=p_x.shape[0] // 10000,
-                                                             lr_x=lr_x, lr_y=lr_y)
+            cg_x, self.iter_num = general_conjugate_gradient(
+                grad_x=grad_x_vec,
+                grad_y=grad_y_vec,
+                x_params=self.G_params,
+                y_params=self.D_params,
+                kk=p_x,
+                x=self.old_x,
+                nsteps=p_x.shape[0] // 10000,
+                lr_x=lr_x,
+                lr_y=lr_y)
             # cg_x.detach_().mul_(p_x_norm)
             cg_x.detach_().mul_(lr_x.sqrt())  # delta x = lr_x.sqrt() * cg_x
-            hcg = Hvp_vec(grad_x_vec, self.D_params, cg_x, retain_graph=True).add_(grad_y_vec).detach_()
+            hcg = Hvp_vec(
+                grad_x_vec, self.D_params, cg_x,
+                retain_graph=True).add_(grad_y_vec).detach_()
             # grad_y + D_yx * delta x
-            cg_y = hcg.mul(- lr_y)
+            cg_y = hcg.mul(-lr_y)
             self.old_y = hcg.mul(lr_y.sqrt())
-            
+
         return error_real.item(), error_fake.item(), g_error.item(), cg_x, cg_y
 
 
 ######################################
-        
+
+
 class Jacobi(Optimizer):
-    
-    def __init__(self, G, D, criterion, lr_x=1e-3,lr_y = 1e-3 , label_smoothing = False):
+    def __init__(self,
+                 G,
+                 D,
+                 criterion,
+                 lr_x=1e-3,
+                 lr_y=1e-3,
+                 label_smoothing=False):
         super(Jacobi, self).__init__(G, D, criterion)
         self.lr_x = lr_x
         self.lr_y = lr_y
         self.label_smoothing = label_smoothing
-        
-    def step(self,real_data, N):
+
+    def step(self, real_data, N):
         self.count += 1
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         #fake_data_copy = self.G(noise(N, 100))
         d_pred_real = self.D(real_data)
         #d_pred_real_copy = self.D(real_data)
         if self.label_smoothing:
-            error_real = self.criterion(d_pred_real, ones_target_smooth(N) )
+            error_real = self.criterion(d_pred_real, ones_target_smooth(N))
         else:
-            error_real = self.criterion(d_pred_real, ones_target(N) )
+            error_real = self.criterion(d_pred_real, ones_target(N))
         #    error_real_copy = self.criterion(d_pred_real_copy, ones_target(N) )
         d_pred_fake = self.D(fake_data)
         #d_pred_fake_copy = self.D(fake_data_copy)
@@ -213,207 +269,248 @@ class Jacobi(Optimizer):
             error_fake = self.criterion(d_pred_fake, zeros_target(N))
         #    error_fake_copy = self.criterion(d_pred_fake_copy, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
-        
+
         loss = error_fake + error_real
         #loss_copy = error_fake_copy + error_real_copy
         #loss = d_pred_real.mean() - d_pred_fake.mean()
-        grad_x = autograd.grad(loss, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_x = autograd.grad(
+            loss, self.G.parameters(), create_graph=True, retain_graph=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        grad_y = autograd.grad(loss, self.D.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_y = autograd.grad(
+            loss, self.D.parameters(), create_graph=True, retain_graph=True)
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
-               
-        hvp_x_vec = Hvp_vec(grad_y_vec, self.G.parameters(), grad_y_vec, retain_graph = True)  # D_xy * grad_y 
-        hvp_y_vec = Hvp_vec(grad_x_vec, self.D.parameters(), grad_x_vec, retain_graph = False)  # D_yx * grad_x
 
-        p_x = torch.add(grad_x_vec, 2*hvp_x_vec).detach_()  # grad_x +2 * D_xy * grad_y
-        p_y = torch.add(-grad_y_vec, -2*hvp_y_vec).detach_()  # grad_y +2 * D_yx * grad_x
-        p_x = p_x.mul_(self.lr_x)     #p_x.mul_(self.lr.sqrt())
-        p_y = p_y.mul_(self.lr_y)     #p_y.mul_(self.lr.sqrt())
-        
+        hvp_x_vec = Hvp_vec(
+            grad_y_vec, self.G.parameters(), grad_y_vec,
+            retain_graph=True)  # D_xy * grad_y
+        hvp_y_vec = Hvp_vec(
+            grad_x_vec, self.D.parameters(), grad_x_vec,
+            retain_graph=False)  # D_yx * grad_x
+
+        p_x = torch.add(grad_x_vec,
+                        2 * hvp_x_vec).detach_()  # grad_x +2 * D_xy * grad_y
+        p_y = torch.add(-grad_y_vec,
+                        -2 * hvp_y_vec).detach_()  # grad_y +2 * D_yx * grad_x
+        p_x = p_x.mul_(self.lr_x)  #p_x.mul_(self.lr.sqrt())
+        p_y = p_y.mul_(self.lr_y)  #p_y.mul_(self.lr.sqrt())
+
         return error_real.item(), error_fake.item(), g_error.item(), p_x, p_y
+
 
 ################################################
 class GaussSeidel(Optimizer):
-    
     def __init__(self, G, D, criterion, lr_x=1e-3, lr_y=1e-3):
-        super(GaussSeidel, self).__init__(G, D, criterion)        
+        super(GaussSeidel, self).__init__(G, D, criterion)
         self.lr_x = lr_x
-        self.lr_y = lr_y       
+        self.lr_y = lr_y
 
-    def step(self,real_data, N):
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+    def step(self, real_data, N):
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         d_pred_real = self.D(real_data)
-        error_real = self.criterion(d_pred_real, ones_target(N) )
+        error_real = self.criterion(d_pred_real, ones_target(N))
         d_pred_fake = self.D(fake_data)
         error_fake = self.criterion(d_pred_fake, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
         loss = error_fake + error_real
         #loss = d_pred_real.mean() - d_pred_fake.mean()
-        grad_x = autograd.grad(loss, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_x = autograd.grad(
+            loss, self.G.parameters(), create_graph=True, retain_graph=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        grad_y = autograd.grad(loss, self.D.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_y = autograd.grad(
+            loss, self.D.parameters(), create_graph=True, retain_graph=True)
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
-        
-        hvp_x_vec = Hvp_vec(grad_y_vec, self.G.parameters(), grad_y_vec ,retain_graph=True)  # D_xy * grad_y 
-        p_x = torch.add(grad_x_vec, 2*hvp_x_vec).detach_()  # grad_x + 2 * D_xy *  grad_y
-        
+
+        hvp_x_vec = Hvp_vec(
+            grad_y_vec, self.G.parameters(), grad_y_vec,
+            retain_graph=True)  # D_xy * grad_y
+        p_x = torch.add(grad_x_vec,
+                        2 * hvp_x_vec).detach_()  # grad_x + 2 * D_xy *  grad_y
+
         p_x.mul_(self.lr_x)
-        
+
         index = 0
         for p in self.G.parameters():
-            p.data.add_(p_x[index: index + p.numel()].reshape(p.shape))
+            p.data.add_(p_x[index:index + p.numel()].reshape(p.shape))
             index += p.numel()
         if index != p_x.numel():
             raise RuntimeError('CG size mismatch')
-        
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         d_pred_fake = self.D(fake_data)
         error_fake = self.criterion(d_pred_fake, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
-        
+
         loss = error_fake + error_real
-        
-        grad_x = autograd.grad(loss, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
+
+        grad_x = autograd.grad(
+            loss, self.G.parameters(), create_graph=True, retain_graph=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        
-        hvp_y_vec = Hvp_vec(grad_x_vec, self.D.parameters(), grad_x_vec ,retain_graph=True)  # D_yx * grad_x
-        p_y = torch.add(-grad_y_vec, -2*hvp_y_vec).detach_()  # grad_y +2 * D_yx * x
+
+        hvp_y_vec = Hvp_vec(
+            grad_x_vec, self.D.parameters(), grad_x_vec,
+            retain_graph=True)  # D_yx * grad_x
+        p_y = torch.add(-grad_y_vec,
+                        -2 * hvp_y_vec).detach_()  # grad_y +2 * D_yx * x
         #p_x = torch.add(grad_x_vec, 2*hvp_x_vec).detach_()  # grad_x +2 * D_xy * y
         p_y.mul_(self.lr_y)
-         
+
         index = 0
         for p in self.D.parameters():
-            p.data.add_(p_y[index: index + p.numel()].reshape(p.shape))
+            p.data.add_(p_y[index:index + p.numel()].reshape(p.shape))
             index += p.numel()
         if index != p_y.numel():
             raise RuntimeError('CG size mismatch')
         return error_real.item(), error_fake.item(), g_error.item()
-    
-        
+
+
 ##########################################
-        
+
+
 class SGD(Optimizer):
-    
-    def __init__(self, G, D, criterion, lr=1e-3): 
-        super(SGD, self).__init__(G, D, criterion)   
+    def __init__(self, G, D, criterion, lr=1e-3):
+        super(SGD, self).__init__(G, D, criterion)
         self.lr = lr
 
-    def step(self,real_data, N):
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+    def step(self, real_data, N):
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         d_pred_real = self.D(real_data)
-        error_real = self.criterion(d_pred_real, ones_target(N) )
+        error_real = self.criterion(d_pred_real, ones_target(N))
         d_pred_fake = self.D(fake_data)
         error_fake = self.criterion(d_pred_fake, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
         loss = error_fake + error_real
         #loss = d_pred_real.mean() - d_pred_fake.mean()
-        grad_x = autograd.grad(loss, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_x = autograd.grad(
+            loss, self.G.parameters(), create_graph=True, retain_graph=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        grad_y = autograd.grad(loss, self.D.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_y = autograd.grad(
+            loss, self.D.parameters(), create_graph=True, retain_graph=True)
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
-        scaled_grad_x = torch.mul(self.lr,grad_x_vec)
-        scaled_grad_y = torch.mul(self.lr,grad_y_vec)
+        scaled_grad_x = torch.mul(self.lr, grad_x_vec)
+        scaled_grad_y = torch.mul(self.lr, grad_y_vec)
 
-        p_x = scaled_grad_x  
-        p_y = scaled_grad_y 
-        
+        p_x = scaled_grad_x
+        p_y = scaled_grad_y
+
         return error_real.item(), error_fake.item(), g_error.item(), p_x, p_y
-         
 
-    
+
 ##############################################################################
 class Newton(Optimizer):
-    
-    def __init__(self, G, D,criterion,  lr_x=1e-3,lr_y = 1e-3):
-        super(Newton, self).__init__(G, D, criterion)   
+    def __init__(self, G, D, criterion, lr_x=1e-3, lr_y=1e-3):
+        super(Newton, self).__init__(G, D, criterion)
         self.lr_x = lr_x
         self.lr_y = lr_y
-        
-    def step(self,real_data, N):
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+
+    def step(self, real_data, N):
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         d_pred_real = self.D(real_data)
-        error_real = self.criterion(d_pred_real, ones_target(N) )
+        error_real = self.criterion(d_pred_real, ones_target(N))
         d_pred_fake = self.D(fake_data)
         error_fake = self.criterion(d_pred_fake, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
         loss = error_fake + error_real
         #loss = d_pred_real.mean() - d_pred_fake.mean()
-        grad_x = autograd.grad(loss, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_x = autograd.grad(
+            loss, self.G.parameters(), create_graph=True, retain_graph=True)
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
-        grad_y = autograd.grad(loss, self.D.parameters(), create_graph=True,
-                               retain_graph=True)
+        grad_y = autograd.grad(
+            loss, self.D.parameters(), create_graph=True, retain_graph=True)
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
-        
-        hvp_x_vec = Hvp_vec(grad_y_vec, self.G.parameters(), grad_y_vec ,retain_graph=True)  # D_xy * grad_y 
-        hvp_y_vec = Hvp_vec(grad_x_vec, self.D.parameters(), grad_x_vec ,retain_graph=True)  # D_yx * grad_x
-        
-        right_side_x = torch.add(grad_x_vec, 2*hvp_x_vec).detach_()  # grad_x + 2 * D_xy * grad_y
-        right_side_y = torch.add(-grad_y_vec, -2*hvp_y_vec).detach_()  # grad_y + 2 * D_yx * grad_x
-        
-        p_x = general_conjugate_gradient_jacobi(grad_x_vec, self.G.parameters(),  right_side_x, x=None, nsteps=1000,
-                               residual_tol=1e-16)
-        p_y = general_conjugate_gradient_jacobi(grad_y_vec, self.D.parameters(),  right_side_y, x=None, nsteps=1000,
-                               residual_tol=1e-16)
+
+        hvp_x_vec = Hvp_vec(
+            grad_y_vec, self.G.parameters(), grad_y_vec,
+            retain_graph=True)  # D_xy * grad_y
+        hvp_y_vec = Hvp_vec(
+            grad_x_vec, self.D.parameters(), grad_x_vec,
+            retain_graph=True)  # D_yx * grad_x
+
+        right_side_x = torch.add(
+            grad_x_vec, 2 * hvp_x_vec).detach_()  # grad_x + 2 * D_xy * grad_y
+        right_side_y = torch.add(
+            -grad_y_vec,
+            -2 * hvp_y_vec).detach_()  # grad_y + 2 * D_yx * grad_x
+
+        p_x = general_conjugate_gradient_jacobi(
+            grad_x_vec,
+            self.G.parameters(),
+            right_side_x,
+            x=None,
+            nsteps=1000,
+            residual_tol=1e-16)
+        p_y = general_conjugate_gradient_jacobi(
+            grad_y_vec,
+            self.D.parameters(),
+            right_side_y,
+            x=None,
+            nsteps=1000,
+            residual_tol=1e-16)
         p_x = p_x[0]
         p_y = p_y[0]
-        
+
         p_x.mul_(self.lr_x)
         p_y.mul_(self.lr_y)
-         
+
         return error_real.item(), error_fake.item(), g_error.item(), p_x, p_y
 
 
 ######################################################################################
-        
+
+
 class JacobiMultiCost(Optimizer):
-    
     def __init__(self, G, D, criterion, lr_x=1e-3, lr_y=1e-3):
-        super(JacobiMultiCost, self).__init__(G, D, criterion)           
+        super(JacobiMultiCost, self).__init__(G, D, criterion)
         self.lr_x = lr_x
         self.lr_y = lr_y
-        
-    def step(self,real_data, N):
-        fake_data = self.G(noise(N, 100)) # Second argument of noise is the noise_dimension parameter of build_generator
+
+    def step(self, real_data, N):
+        fake_data = self.G(
+            noise(N, 100)
+        )  # Second argument of noise is the noise_dimension parameter of build_generator
         d_pred_real = self.D(real_data)
-        error_real = self.criterion(d_pred_real, ones_target(N) )
+        error_real = self.criterion(d_pred_real, ones_target(N))
         d_pred_fake = self.D(fake_data)
         error_fake = self.criterion(d_pred_fake, zeros_target(N))
         g_error = self.criterion(d_pred_fake, ones_target(N))
-        
+
         f = error_fake + error_real  # f cost relative to discriminator
-        g = g_error                  # g cost relative to generator
+        g = g_error  # g cost relative to generator
         #loss = d_pred_real.mean() - d_pred_fake.mean()
-        grad_f_x = autograd.grad(f, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
-        grad_g_x = autograd.grad(g, self.G.parameters(), create_graph=True,
-                               retain_graph=True)
-        grad_f_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_f_x]) 
+        grad_f_x = autograd.grad(
+            f, self.G.parameters(), create_graph=True, retain_graph=True)
+        grad_g_x = autograd.grad(
+            g, self.G.parameters(), create_graph=True, retain_graph=True)
+        grad_f_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_f_x])
         grad_g_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_g_x])
-        
-        grad_f_y = autograd.grad(f, self.D.parameters(), create_graph=True,
-                               retain_graph=True)
-        grad_g_y = autograd.grad(g, self.D.parameters(), create_graph=True,
-                               retain_graph=True)
-        grad_f_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_f_y]) 
-        grad_g_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_g_y]) 
 
-        
-        D_f_xy = Hvp_vec(grad_f_y_vec, self.G.parameters(), grad_f_y_vec, retain_graph = True)
-        D_g_yx = Hvp_vec(grad_g_x_vec, self.D.parameters(), grad_g_x_vec, retain_graph = True)
+        grad_f_y = autograd.grad(
+            f, self.D.parameters(), create_graph=True, retain_graph=True)
+        grad_g_y = autograd.grad(
+            g, self.D.parameters(), create_graph=True, retain_graph=True)
+        grad_f_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_f_y])
+        grad_g_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_g_y])
 
-        p_x = torch.add(grad_f_x_vec, 2*D_f_xy).detach_()  # grad_x + 2*D_xy * grad_y
-        p_y = torch.add(grad_g_y_vec, 2*D_g_yx).detach_()  # grad_y + 2*D_yx * grad_x
+        D_f_xy = Hvp_vec(
+            grad_f_y_vec, self.G.parameters(), grad_f_y_vec, retain_graph=True)
+        D_g_yx = Hvp_vec(
+            grad_g_x_vec, self.D.parameters(), grad_g_x_vec, retain_graph=True)
+
+        p_x = torch.add(grad_f_x_vec,
+                        2 * D_f_xy).detach_()  # grad_x + 2*D_xy * grad_y
+        p_y = torch.add(grad_g_y_vec,
+                        2 * D_g_yx).detach_()  # grad_y + 2*D_yx * grad_x
         p_x.mul_(self.lr_x)
         p_y.mul_(self.lr_y)
-         
-        error_real.item(), error_fake.item(), g_error.item(), p_x, p_y
-#################################################################################
 
+        error_real.item(), error_fake.item(), g_error.item(), p_x, p_y
+
+
+#################################################################################

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ import math
 
 ################################################################
 
+
 def ones_target(size):
     '''
     Tensor containing ones, with shape = size
@@ -25,12 +26,14 @@ def ones_target(size):
     data = Variable(torch.ones(size, 1))
     return data
 
+
 def ones_target_smooth(size):
     '''
     Tensor containing 0.9s, with shape = size
     '''
-    data = torch.full((size,), 0.9)
+    data = torch.full((size, ), 0.9)
     return data
+
 
 def zeros_target(size):
     '''
@@ -39,12 +42,14 @@ def zeros_target(size):
     data = Variable(torch.zeros(size, 1))
     return data
 
+
 def zeros_target_smooth(size):
     '''
     Tensor containing zeros, with shape = size
     '''
-    data = torch.full((size,), 0.1)
+    data = torch.full((size, ), 0.1)
     return data
+
 
 def noise(size, noise_size):
     '''
@@ -53,32 +58,40 @@ def noise(size, noise_size):
     n = Variable(torch.randn(size, noise_size))
     return n
 
+
 def images_to_vectors(images):
-    image_dim = images.size(1)*images.size(2)*images.size(3)
-    return images.view(images.size(0), image_dim) 
+    image_dim = images.size(1) * images.size(2) * images.size(3)
+    return images.view(images.size(0), image_dim)
+
 
 def vectors_to_images(vectors, array_dim):
-    return vectors.view(vectors.size(0), array_dim[0],array_dim[1],array_dim[2])
+    return vectors.view(
+        vectors.size(0), array_dim[0], array_dim[1], array_dim[2])
+
 
 def images_to_vectors_cifar10(images):
     return images.view(images.size(0), 3072)
 
+
 def vectors_to_images_cifar10(vectors):
     return vectors.view(vectors.size(0), 3, 32, 32)
 
+
 #############################################################################
-    
+
+
 def zero_grad(params):
     for p in params:
         if p.grad is not None:
             p.grad.detach()
             p.grad.zero_()
-    
+
+
 def init_weights(m):
     classname = m.__class__.__name__
     if classname.find('Conv') != -1 or classname.find('BatchNorm') != -1:
         m.weight.data.normal_(0.00, 0.02)
-            
+
 
 def Hvp_vec(grad_vec, params, vec, retain_graph=False):
     if torch.isnan(grad_vec).any():
@@ -88,15 +101,20 @@ def Hvp_vec(grad_vec, params, vec, retain_graph=False):
         print('vec nan')
         raise ValueError('vec Nan')
     try:
-        grad_grad = autograd.grad(grad_vec, params, grad_outputs=vec, retain_graph=retain_graph)
+        grad_grad = autograd.grad(
+            grad_vec, params, grad_outputs=vec, retain_graph=retain_graph)
         hvp = torch.cat([g.contiguous().view(-1) for g in grad_grad])
         if torch.isnan(hvp).any():
             print('hvp nan')
             raise ValueError('hvp Nan')
     except:
         # print('filling zero for None')
-        grad_grad = autograd.grad(grad_vec, params, grad_outputs=vec, retain_graph=retain_graph,
-                                  allow_unused=True)
+        grad_grad = autograd.grad(
+            grad_vec,
+            params,
+            grad_outputs=vec,
+            retain_graph=retain_graph,
+            allow_unused=True)
         grad_list = []
         for i, p in enumerate(params):
             if grad_grad[i] is None:
@@ -108,9 +126,15 @@ def Hvp_vec(grad_vec, params, vec, retain_graph=False):
             raise ValueError('hvp Nan')
     return hvp
 
+
 def hessian_vec(grad_vec, var, retain_graph=False):
     v = torch.ones_like(var)
-    vec, = autograd.grad(grad_vec, var, grad_outputs=v, allow_unused=True, retain_graph=retain_graph)
+    vec, = autograd.grad(
+        grad_vec,
+        var,
+        grad_outputs=v,
+        allow_unused=True,
+        retain_graph=retain_graph)
     return vec
 
 
@@ -120,9 +144,7 @@ def binary_cross_entropy(x, y):
 
 
 class Richardson(object):
-
     def __init__(self, matrix, rhs, tol, maxiter, relaxation, verbose=False):
-
         """
         :param matrix: coefficient matrix
         :param rhs: right hand side
@@ -143,7 +165,7 @@ class Richardson(object):
         self.verbose = verbose
 
     def print_verbose(self, *args, **kwargs):
-        if self.verbose :
+        if self.verbose:
             print(*args, **kwargs)
 
     def solve(self, initial_guess):
@@ -158,20 +180,31 @@ class Richardson(object):
         while relative_residual_norm > self.tol and self.iteration_count < self.maxiter:
             ## TODO: consider making all of these non-attributes and just return them
             solution = solution + self.relaxation * residual
-            
+
             residual = self.rhs - torch.matmul(self.matrix, solution)
             residual_norm = residual.norm()
             relative_residual_norm = residual_norm / self.rhs_norm
             self.iteration_count += 1
-            self.print_verbose("Richardson converged in ", str(self.iteration_count), " iteration with relative residual norm: ",
-                                     str(relative_residual_norm), end='...')
+            self.print_verbose(
+                "Richardson converged in ",
+                str(self.iteration_count),
+                " iteration with relative residual norm: ",
+                str(relative_residual_norm),
+                end='...')
 
         # Do not return because it's already an attribute
         return solution
-    
 
 
-def general_conjugate_gradient(grad_x, grad_y, x_params, y_params, kk, lr_x, lr_y, x=None, nsteps=10,
+def general_conjugate_gradient(grad_x,
+                               grad_y,
+                               x_params,
+                               y_params,
+                               kk,
+                               lr_x,
+                               lr_y,
+                               x=None,
+                               nsteps=10,
                                residual_tol=1e-16,
                                device=torch.device('cpu')):
     '''
@@ -204,18 +237,22 @@ def general_conjugate_gradient(grad_x, grad_y, x_params, y_params, kk, lr_x, lr_
     for i in range(nsteps):
         # To compute Avp
         # h_1 = Hvp_vec(grad_vec=grad_x, params=y_params, vec=lr_x * p, retain_graph=True)
-        h_1 = Hvp_vec(grad_vec=grad_x, params=y_params, vec=lr_x * jj, retain_graph=True).mul_(lr_y)
+        h_1 = Hvp_vec(
+            grad_vec=grad_x, params=y_params, vec=lr_x * jj,
+            retain_graph=True).mul_(lr_y)
         # h_1.mul_(lr_y)
         # lr_y * D_yx * b
         # h_2 = Hvp_vec(grad_vec=grad_y, params=x_params, vec=lr_y * h_1, retain_graph=True)
-        h_2 = Hvp_vec(grad_vec=grad_y, params=x_params, vec=h_1, retain_graph=True).mul_(lr_x)
+        h_2 = Hvp_vec(
+            grad_vec=grad_y, params=x_params, vec=h_1,
+            retain_graph=True).mul_(lr_x)
         # h_2.mul_(lr_x)
         # lr_x * D_xy * lr_y * D_yx * b
         Avp_ = jj + h_2
 
         alpha = rdotr / torch.dot(jj, Avp_)
         x.data.add_(alpha * jj)
-        mm.data.add_(- alpha * Avp_)
+        mm.data.add_(-alpha * Avp_)
         new_rdotr = torch.dot(mm, mm)
         beta = new_rdotr / rdotr
         jj = mm + beta * jj
@@ -224,10 +261,15 @@ def general_conjugate_gradient(grad_x, grad_y, x_params, y_params, kk, lr_x, lr_
             break
     return x, i + 1
 
+
 #######################################################################
-def general_conjugate_gradient_jacobi(grad_x, x_params, right_side, x=None, nsteps=10,
-                               residual_tol=1e-16,
-                               device=torch.device('cpu')):
+def general_conjugate_gradient_jacobi(grad_x,
+                                      x_params,
+                                      right_side,
+                                      x=None,
+                                      nsteps=10,
+                                      residual_tol=1e-16,
+                                      device=torch.device('cpu')):
     '''
 
     :param grad_x:
@@ -246,22 +288,23 @@ def general_conjugate_gradient_jacobi(grad_x, x_params, right_side, x=None, nste
     '''
     if x is None:
         x = torch.zeros(right_side.shape[0], device=device)
-    
+
     right_side_clone1 = right_side.clone().detach()
     right_side_clone2 = right_side_clone1.clone().detach()
-    
+
     rdotr = torch.dot(right_side_clone1, right_side_clone1)
     residual_tol = residual_tol * rdotr
     x_params = tuple(x_params)
-    
+
     for i in range(nsteps):
-        h_1 = Hvp_vec(grad_vec=grad_x, params=x_params, vec= 2 * x, retain_graph=True)
+        h_1 = Hvp_vec(
+            grad_vec=grad_x, params=x_params, vec=2 * x, retain_graph=True)
         H = -h_1 + x
         Avp_ = right_side_clone2 + H
 
         alpha = rdotr / torch.dot(right_side_clone2, Avp_)
         x.data.add_(alpha * right_side_clone2)
-        right_side_clone1.data.add_(- alpha * Avp_)
+        right_side_clone1.data.add_(-alpha * Avp_)
         new_rdotr = torch.dot(right_side_clone1, right_side_clone1)
         beta = new_rdotr / rdotr
         right_side_clone2 = right_side_clone1 + beta * right_side_clone2
@@ -269,5 +312,6 @@ def general_conjugate_gradient_jacobi(grad_x, x_params, right_side, x=None, nste
         if rdotr < residual_tol:
             break
     return x, i + 1
+
 
 ###########################################

--- a/utils.py
+++ b/utils.py
@@ -215,8 +215,8 @@ def general_conjugate_gradient(grad_x,
     :param y_params:
     :param b:
     :param lr_x:
-    :param lr_y:      
-    :param x:            
+    :param lr_y:
+    :param x:
     :param nsteps:
     :param residual_tol:
     :param device:
@@ -278,8 +278,8 @@ def general_conjugate_gradient_jacobi(grad_x,
     :param y_params:
     :param b:
     :param lr_x:
-    :param lr_y:      
-    :param x:            
+    :param lr_y:
+    :param x:
     :param nsteps:
     :param residual_tol:
     :param device:


### PR DESCRIPTION
This is simply an example of how we could come to a style. I used [yapf](https://github.com/google/yapf) tool, that was run on all Python files. I care less about the details of a style, and more about having one. 

If we don't like how some of the code was formatted, it can be disabled for those pieces of code using `# yapf: disable`.

If we agree that this (or a modification of it) is a style we want to have, we would want to install the pre-commit hooks in our local repos to make sure all commits follow it.

Thoughts?

Fix #22. I also had to fix `Dataloader.py` as it was carrying the wrong new lines code (probably created in Windows).