### PR TITLE
Revert "black formatting run"

### DIFF
--- a/DCGANs_object.py
+++ b/DCGANs_object.py
@@ -46,11 +46,11 @@ class DCGANs_model(GANs_model):
         loss=torch.nn.BCEWithLogitsLoss(),
         lr_x=torch.tensor([0.01]),
         lr_y=torch.tensor([0.01]),
-        optimizer_name="Jacobi",
+        optimizer_name='Jacobi',
         num_epochs=1,
         batch_size=100,
         verbose=True,
-        save_path="./data_fake_DCGANS",
+        save_path='./data_fake_DCGANS',
         label_smoothing=False,
         single_number=None,
     ):
@@ -59,7 +59,9 @@ class DCGANs_model(GANs_model):
         )
         if single_number is not None:
             self.num_test_samples = 5
-            self.data = [i for i in self.data if i[1] == torch.tensor(single_number)]
+            self.data = [
+                i for i in self.data if i[1] == torch.tensor(single_number)
+            ]
             self.data_loader = torch.utils.data.DataLoader(
                 self.data, batch_size=100, shuffle=True
             )
@@ -74,48 +76,62 @@ class DCGANs_model(GANs_model):
         self.verbose = verbose
         self.save_path = save_path
         self.test_noise = noise(self.num_test_samples, self.noise_dimension)
-        self.optimizer_initialize(loss, lr_x, lr_y, optimizer_name, label_smoothing)
+        self.optimizer_initialize(
+            loss, lr_x, lr_y, optimizer_name, label_smoothing
+        )
         start = time.time()
         for e in range(num_epochs):
-            self.print_verbose("######################################################")
+            self.print_verbose(
+                "######################################################"
+            )
             for n_batch, (real_batch, _) in enumerate(self.data_loader):
                 real_data = Variable((real_batch))
                 N = real_batch.size(0)
                 self.optimizer.zero_grad()
-                if optimizer_name == "GaussSeidel":
-                    error_real, error_fake, g_error = self.optimizer.step(real_data, N)
+                if optimizer_name == 'GaussSeidel':
+                    error_real, error_fake, g_error = self.optimizer.step(
+                        real_data, N
+                    )
                     self.D = optimizer.D
                     self.G = optimizer.G
                 else:
-                    (error_real, error_fake, g_error, p_x, p_y,) = self.optimizer.step(
-                        real_data, N
-                    )
+                    (
+                        error_real,
+                        error_fake,
+                        g_error,
+                        p_x,
+                        p_y,
+                    ) = self.optimizer.step(real_data, N)
 
                     index = 0
                     for p in self.G.parameters():
-                        p.data.add_(p_x[index : index + p.numel()].reshape(p.shape))
+                        p.data.add_(
+                            p_x[index : index + p.numel()].reshape(p.shape)
+                        )
                         index += p.numel()
                     if index != p_x.numel():
-                        raise RuntimeError("CG size mismatch")
+                        raise RuntimeError('CG size mismatch')
                     index = 0
                     for p in self.D.parameters():
-                        p.data.add_(p_y[index : index + p.numel()].reshape(p.shape))
+                        p.data.add_(
+                            p_y[index : index + p.numel()].reshape(p.shape)
+                        )
                         index += p.numel()
                     if index != p_y.numel():
-                        raise RuntimeError("CG size mismatch")
+                        raise RuntimeError('CG size mismatch')
 
                 self.D_error_real_history.append(error_real)
                 self.D_error_fake_history.append(error_fake)
                 self.G_error_history.append(g_error)
 
-                self.print_verbose("Epoch: ", str(e + 1), "/", str(num_epochs))
-                self.print_verbose("Batch Number: ", str(n_batch + 1))
+                self.print_verbose('Epoch: ', str(e + 1), '/', str(num_epochs))
+                self.print_verbose('Batch Number: ', str(n_batch + 1))
                 self.print_verbose(
-                    "Error_discriminator__real: ",
+                    'Error_discriminator__real: ',
                     "{:.5e}".format(error_real),
-                    "Error_discriminator__fake: ",
+                    'Error_discriminator__fake: ',
                     "{:.5e}".format(error_fake),
-                    "Error_generator: ",
+                    'Error_generator: ',
                     "{:.5e}".format(g_error),
                 )
 
@@ -123,6 +139,8 @@ class DCGANs_model(GANs_model):
                     test_images = self.optimizer.G(self.test_noise)
                     self.save_images(e, n_batch, test_images)
 
-            self.print_verbose("######################################################")
+            self.print_verbose(
+                "######################################################"
+            )
         end = time.time()
-        self.print_verbose("Total Time[s]: ", str(end - start))
+        self.print_verbose('Total Time[s]: ', str(end - start))

--- a/Dataloader.py
+++ b/Dataloader.py
@@ -33,17 +33,24 @@ def mnist_data(rand_rotation=False, max_degree=90):
             [transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))]
         )
 
-    out_dir = "./dataset"
-    return datasets.MNIST(root=out_dir, train=True, transform=compose, download=True)
+    out_dir = './dataset'
+    return datasets.MNIST(
+        root=out_dir, train=True, transform=compose, download=True
+    )
 
 
 def cifar10_data():
 
     compose = transforms.Compose(
-        [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),]
+        [
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+        ]
     )
-    out_dir = "./dataset"
-    return datasets.CIFAR10(root=out_dir, train=True, transform=compose, download=True)
+    out_dir = './dataset'
+    return datasets.CIFAR10(
+        root=out_dir, train=True, transform=compose, download=True
+    )
 
 
 def mnist_data_dcgans(rand_rotation=False, max_degree=90):
@@ -65,8 +72,10 @@ def mnist_data_dcgans(rand_rotation=False, max_degree=90):
                 transforms.Normalize((0.5,), (0.5,)),
             ]
         )
-    out_dir = "{}/dataset".format(os.getcwd())
-    return datasets.MNIST(root=out_dir, train=True, transform=compose, download=True)
+    out_dir = '{}/dataset'.format(os.getcwd())
+    return datasets.MNIST(
+        root=out_dir, train=True, transform=compose, download=True
+    )
 
 
 def cifar_data_dcgans():
@@ -77,5 +86,7 @@ def cifar_data_dcgans():
             transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
         ]
     )
-    out_dir = "{}/dataset".format(os.getcwd())
-    return datasets.CIFAR10(root=out_dir, train=True, transform=compose, download=True)
+    out_dir = '{}/dataset'.format(os.getcwd())
+    return datasets.CIFAR10(
+        root=out_dir, train=True, transform=compose, download=True
+    )

--- a/GANs_abstract_object.py
+++ b/GANs_abstract_object.py
@@ -32,9 +32,9 @@ class GANs_model(object):
         self.G_error_history = []
 
         if self.data_dimension[0] == 3:
-            self.imtype = "RGB"
+            self.imtype = 'RGB'
         else:
-            self.imtype = "gray"
+            self.imtype = 'gray'
 
     def print_verbose(self, *args, **kwargs):
         if self.verbose:
@@ -45,13 +45,13 @@ class GANs_model(object):
             if not os.path.exists(directory):
                 os.makedirs(directory)
         except OSError:
-            print("Error: Creating directory. " + directory)
+            print('Error: Creating directory. ' + directory)
 
     def save_models(self):
         # G_directory = self.createFolder("/G_model")
         # D_directory = self.createFolder("/D_model")
-        filename_D = "D_state_dict.pth"
-        filename_G = "G_state_dict.pth"
+        filename_D = 'D_state_dict.pth'
+        filename_G = 'G_state_dict.pth'
         torch.save(self.G.state_dict(), filename_G)
         torch.save(self.D.state_dict(), filename_D)
 
@@ -71,17 +71,19 @@ class GANs_model(object):
     def optimizer_initialize(
         self, loss, lr_x, lr_y, optimizer_name, label_smoothing=False
     ):
-        if optimizer_name == "Jacobi":
-            self.optimizer = Jacobi(self.G, self.D, loss, lr_x, lr_y, label_smoothing)
-        elif optimizer_name == "CGD":
+        if optimizer_name == 'Jacobi':
+            self.optimizer = Jacobi(
+                self.G, self.D, loss, lr_x, lr_y, label_smoothing
+            )
+        elif optimizer_name == 'CGD':
             self.optimizer = CGD(self.G, self.D, loss, lr_x)
-        elif optimizer_name == "Newton":
+        elif optimizer_name == 'Newton':
             self.optimizer = Newton(self.G, self.D, loss, lr_x, lr_y)
-        elif optimizer_name == "JacobiMultiCost":
+        elif optimizer_name == 'JacobiMultiCost':
             self.optimizer = JacobiMultiCost(self.G, self.D, loss, lr_x, lr_y)
-        elif optimizer_name == "GaussSeidel":
+        elif optimizer_name == 'GaussSeidel':
             self.optimizer = GaussSeidel(self.G, self.D, loss, lr_x, lr_y)
-        elif optimizer_name == "SGD":
+        elif optimizer_name == 'SGD':
             self.optimizer = SGD(self.G, self.D, loss, lr_x)
         else:
             raise RuntimeError("Optimizer type is not valid")
@@ -90,7 +92,7 @@ class GANs_model(object):
         count = 0
         for image_index in range(0, images.shape[0]):
             count = count + 1
-            if self.imtype == "RGB":
+            if self.imtype == 'RGB':
                 image = images[image_index]  # [0]
                 image = image.detach().numpy()
                 image = (image + 1) / 2
@@ -98,32 +100,32 @@ class GANs_model(object):
                 self.createFolder(self.save_path)
                 path = str(
                     self.save_path
-                    + "/fake_image"
-                    + "_Epoch_"
+                    + '/fake_image'
+                    + '_Epoch_'
                     + str(e + 1)
-                    + "_Batch_"
+                    + '_Batch_'
                     + str(n_batch)
-                    + "_N_image_"
+                    + '_N_image_'
                     + str(count)
-                    + ".png"
+                    + '.png'
                 )
                 plt.imsave(path, image)
             else:
                 image = images[image_index][0]
                 image = image.detach().numpy()
                 image = (image + 1) / 2
-                img = pil.fromarray(np.uint8(image * 255), "L")
+                img = pil.fromarray(np.uint8(image * 255), 'L')
                 self.createFolder(self.save_path)
                 path = str(
                     self.save_path
-                    + "/fake_image"
-                    + "_Epoch_"
+                    + '/fake_image'
+                    + '_Epoch_'
                     + str(epoch_number + 1)
-                    + "_Batch_"
+                    + '_Batch_'
                     + str(n_batch)
-                    + "_N_image_"
+                    + '_N_image_'
                     + str(count)
-                    + ".png"
+                    + '.png'
                 )
                 img.save(path)
 
@@ -133,11 +135,11 @@ class GANs_model(object):
         loss=torch.nn.BCEWithLogitsLoss(),
         lr_x=torch.tensor([0.001]),
         lr_y=torch.tensor([0.001]),
-        optimizer_name="Jacobi",
+        optimizer_name='Jacobi',
         num_epochs=1,
         batch_size=100,
         verbose=True,
-        save_path="./data_fake",
+        save_path='./data_fake',
         label_smoothing=False,
         single_number=None,
     ):

--- a/MLP_GANs_object.py
+++ b/MLP_GANs_object.py
@@ -45,16 +45,18 @@ class MLP_GANs_model(GANs_model):
         loss=torch.nn.BCEWithLogitsLoss(),
         lr_x=torch.tensor([0.001]),
         lr_y=torch.tensor([0.001]),
-        optimizer_name="SGD",
+        optimizer_name='SGD',
         num_epochs=1,
         batch_size=100,
         verbose=True,
-        save_path="./data_fake",
+        save_path='./data_fake',
         label_smoothing=False,
         single_number=None,
     ):
         if single_number is not None:
-            self.data = [i for i in self.data if i[1] == torch.tensor(single_number)]
+            self.data = [
+                i for i in self.data if i[1] == torch.tensor(single_number)
+            ]
             self.data_loader = torch.utils.data.DataLoader(
                 self.data, batch_size=100, shuffle=True
             )
@@ -70,10 +72,14 @@ class MLP_GANs_model(GANs_model):
         self.verbose = verbose
         self.save_path = save_path
         self.test_noise = noise(self.num_test_samples, self.noise_dimension)
-        self.optimizer_initialize(loss, lr_x, lr_y, optimizer_name, label_smoothing)
+        self.optimizer_initialize(
+            loss, lr_x, lr_y, optimizer_name, label_smoothing
+        )
         start = time.time()
         for e in range(num_epochs):
-            self.print_verbose("######################################################")
+            self.print_verbose(
+                "######################################################"
+            )
             for n_batch, (real_batch, _) in enumerate(self.data_loader):
                 N = real_batch.size(0)
                 real_data = Variable(images_to_vectors(real_batch))
@@ -81,39 +87,49 @@ class MLP_GANs_model(GANs_model):
                 self.optimizer.D = self.D
                 self.optimizer.zero_grad()
 
-                if optimizer_name == "GaussSeidel":
-                    error_real, error_fake, g_error = self.optimizer.step(real_data, N)
+                if optimizer_name == 'GaussSeidel':
+                    error_real, error_fake, g_error = self.optimizer.step(
+                        real_data, N
+                    )
                     self.D = self.optimizer.D
                     self.G = self.optimizer.G
                 else:
-                    (error_real, error_fake, g_error, p_x, p_y,) = self.optimizer.step(
-                        real_data, N
-                    )
+                    (
+                        error_real,
+                        error_fake,
+                        g_error,
+                        p_x,
+                        p_y,
+                    ) = self.optimizer.step(real_data, N)
                     index = 0
                     for p in self.G.parameters():
-                        p.data.add_(p_x[index : index + p.numel()].reshape(p.shape))
+                        p.data.add_(
+                            p_x[index : index + p.numel()].reshape(p.shape)
+                        )
                         index += p.numel()
                     if index != p_x.numel():
-                        raise RuntimeError("CG size mismatch")
+                        raise RuntimeError('CG size mismatch')
                     index = 0
                     for p in self.D.parameters():
-                        p.data.add_(p_y[index : index + p.numel()].reshape(p.shape))
+                        p.data.add_(
+                            p_y[index : index + p.numel()].reshape(p.shape)
+                        )
                         index += p.numel()
                     if index != p_y.numel():
-                        raise RuntimeError("CG size mismatch")
+                        raise RuntimeError('CG size mismatch')
 
                 self.D_error_real_history.append(error_real)
                 self.D_error_fake_history.append(error_fake)
                 self.G_error_history.append(g_error)
 
-                self.print_verbose("Epoch: ", str(e + 1), "/", str(num_epochs))
-                self.print_verbose("Batch Number: ", str(n_batch + 1))
+                self.print_verbose('Epoch: ', str(e + 1), '/', str(num_epochs))
+                self.print_verbose('Batch Number: ', str(n_batch + 1))
                 self.print_verbose(
-                    "Error_discriminator__real: ",
+                    'Error_discriminator__real: ',
                     "{:.5e}".format(error_real),
-                    "Error_discriminator__fake: ",
+                    'Error_discriminator__fake: ',
                     "{:.5e}".format(error_fake),
-                    "Error_generator: ",
+                    'Error_generator: ',
                     "{:.5e}".format(g_error),
                 )
 
@@ -123,6 +139,8 @@ class MLP_GANs_model(GANs_model):
                     )  # data_dimension: dimension of output image ex: [1,28,28]
                     self.save_images(e, n_batch, test_images)
 
-            self.print_verbose("######################################################")
+            self.print_verbose(
+                "######################################################"
+            )
         end = time.time()
-        self.print_verbose("Total Time[s]: ", str(end - start))
+        self.print_verbose('Total Time[s]: ', str(end - start))

--- a/main_GANs.py
+++ b/main_GANs.py
@@ -26,7 +26,7 @@ from docopt import docopt
 from MLP_GANs_object import *
 from DCGANs_object import *
 
-"""
+'''
 ! READ ME !
 Multi-layer perceptrons neural networks (MLP), convolutional neural networks (CNN)
 X = Generator
@@ -47,32 +47,32 @@ inside your current directory
 
 TO TRY: Setting much lower learning rates to see if model collapse is avoided (ex. lr_x = 0.0001 , lr_y = 0.0004)
 
-"""
+'''
 
-if __name__ == "__main__":
-    arguments = docopt(__doc__, version="Competitive Gradient Descent 0.0")
+if __name__ == '__main__':
+    arguments = docopt(__doc__, version='Competitive Gradient Descent 0.0')
     print("Input parameters:")
     for arg in arguments:
         if arguments[arg]:
             print("  {}  {}".format(arg, arguments[arg]))
 
-    epochs = int(arguments["--epochs"])
-    optimizer_name = arguments["--optimizer"]
-    learning_rate = float(arguments["--learning_rate"])
+    epochs = int(arguments['--epochs'])
+    optimizer_name = arguments['--optimizer']
+    learning_rate = float(arguments['--learning_rate'])
 
-    model_switch = arguments["--model"]
+    model_switch = arguments['--model']
 
-    if model_switch == "MLP":
+    if model_switch == 'MLP':
         print("Using MLP implementation of GANs: MLP_GANs_model")
         model = MLP_GANs_model(mnist_data(rand_rotation=False, max_degree=90))
-    elif model_switch == "CNN":
+    elif model_switch == 'CNN':
         print("Using CNN implementation of GANs: DCGANs_model")
         model = DCGANs_model(
             mnist_data_dcgans(rand_rotation=False, max_degree=90)
         )
     else:
         sys.exit(
-            "\n   *** Error. Specified model name: {} is not valid. Please choose MLP or CNN".format(
+            '\n   *** Error. Specified model name: {} is not valid. Please choose MLP or CNN'.format(
                 model_switch
             )
         )
@@ -87,11 +87,11 @@ if __name__ == "__main__":
         single_number=4,
     )  # save_path = ''
 
-    if arguments["--save"]:
+    if arguments['--save']:
         print("Saving the model...")
         model.save_models()
 
-    if arguments["--display"]:
+    if arguments['--display']:
         plt.figure()
         plt.plot(
             [x for x in range(0, len(model.D_error_real_history))],
@@ -105,13 +105,13 @@ if __name__ == "__main__":
             [x for x in range(0, len(model.G_error_history))],
             model.G_error_history,
         )
-        plt.xlabel("Iterations")
-        plt.ylabel("Loss function value")
+        plt.xlabel('Iterations')
+        plt.ylabel('Loss function value')
         plt.legend(
             [
-                "Discriminator: Loss on Real Data",
-                "Discriminator: Loss on Fake Data",
-                "Generator: Loss",
+                'Discriminator: Loss on Real Data',
+                'Discriminator: Loss on Fake Data',
+                'Generator: Loss',
             ]
         )
-        plt.savefig("cost_report.png")
+        plt.savefig('cost_report.png')

--- a/models.py
+++ b/models.py
@@ -49,7 +49,9 @@ class GeneratorCNN(nn.Module):
         super(GeneratorCNN, self).__init__()
 
         self.init_size = image_dimension // 4
-        self.l1 = nn.Sequential(nn.Linear(noise_dimension, 128 * self.init_size ** 2))
+        self.l1 = nn.Sequential(
+            nn.Linear(noise_dimension, 128 * self.init_size ** 2)
+        )
 
         self.conv_blocks = nn.Sequential(
             nn.BatchNorm2d(128),
@@ -95,7 +97,9 @@ class DiscriminatorCNN(nn.Module):
 
         # The height and width of downsampled image
         ds_size = image_dimension // 2 ** 4
-        self.adv_layer = nn.Sequential(nn.Linear(128 * ds_size ** 2, 1), nn.Sigmoid())
+        self.adv_layer = nn.Sequential(
+            nn.Linear(128 * ds_size ** 2, 1), nn.Sigmoid()
+        )
 
     def forward(self, img):
         out = self.model(img)

--- a/optimizers.py
+++ b/optimizers.py
@@ -5,14 +5,14 @@
         : Simona Perotto (e-mail: simona.perotto@polimi.it)
 
 """
-"""
+'''
 CGD_shafer: Original implementation by Shafer
 CGD: Ours implementation of CGD
 Jacobi: Ours implementation of CGD with Jacobi method
 JacobiMultiCost: Ours implementation of Jacobi with 2 different cost functions
 GaussSeidel: GaussSeidel variation of the algorithm
 Newton: Same algorithm but with pure essian term not set to identity
-"""
+'''
 
 import time
 import torch
@@ -64,7 +64,10 @@ class CGD(Optimizer):
         )
         grad_x_vec = torch.cat([g.contiguous().view(-1) for g in grad_x])
         grad_y = autograd.grad(
-            error_tot, self.D.parameters(), create_graph=True, retain_graph=True,
+            error_tot,
+            self.D.parameters(),
+            create_graph=True,
+            retain_graph=True,
         )
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
         scaled_grad_x = torch.mul(self.lr, grad_x_vec)
@@ -110,7 +113,9 @@ class CGD(Optimizer):
 
 
 class CGD_shafer(Optimizer):
-    def __init__(self, G, D, criterion, eps=1e-8, beta2=0.99, lr=1e-3, solve_x=False):
+    def __init__(
+        self, G, D, criterion, eps=1e-8, beta2=0.99, lr=1e-3, solve_x=False
+    ):
         super(CGD_shafer, self).__init__(G, D, criterion)
         self.G_params = list(G.parameters())
         self.D_params = list(D.parameters())
@@ -147,8 +152,12 @@ class CGD_shafer(Optimizer):
         grad_y_vec = torch.cat([g.contiguous().view(-1) for g in grad_y])
 
         if self.square_avgx is None and self.square_avgy is None:
-            self.square_avgx = torch.zeros(grad_x_vec.size(), requires_grad=False)
-            self.square_avgy = torch.zeros(grad_y_vec.size(), requires_grad=False)
+            self.square_avgx = torch.zeros(
+                grad_x_vec.size(), requires_grad=False
+            )
+            self.square_avgy = torch.zeros(
+                grad_y_vec.size(), requires_grad=False
+            )
         self.square_avgx.mul_(self.beta2).addcmul_(
             1 - self.beta2, grad_x_vec.data, grad_x_vec.data
         )
@@ -248,7 +257,9 @@ class CGD_shafer(Optimizer):
 
 
 class Jacobi(Optimizer):
-    def __init__(self, G, D, criterion, lr_x=1e-3, lr_y=1e-3, label_smoothing=False):
+    def __init__(
+        self, G, D, criterion, lr_x=1e-3, lr_y=1e-3, label_smoothing=False
+    ):
         super(Jacobi, self).__init__(G, D, criterion)
         self.lr_x = lr_x
         self.lr_y = lr_y
@@ -348,7 +359,7 @@ class GaussSeidel(Optimizer):
             p.data.add_(p_x[index : index + p.numel()].reshape(p.shape))
             index += p.numel()
         if index != p_x.numel():
-            raise RuntimeError("CG size mismatch")
+            raise RuntimeError('CG size mismatch')
 
         fake_data = self.G(
             noise(N, 100)
@@ -367,7 +378,9 @@ class GaussSeidel(Optimizer):
         hvp_y_vec = Hvp_vec(
             grad_x_vec, self.D.parameters(), grad_x_vec, retain_graph=True
         )  # D_yx * grad_x
-        p_y = torch.add(-grad_y_vec, -2 * hvp_y_vec).detach_()  # grad_y +2 * D_yx * x
+        p_y = torch.add(
+            -grad_y_vec, -2 * hvp_y_vec
+        ).detach_()  # grad_y +2 * D_yx * x
         # p_x = torch.add(grad_x_vec, 2*hvp_x_vec).detach_()  # grad_x +2 * D_xy * y
         p_y.mul_(self.lr_y)
 
@@ -376,7 +389,7 @@ class GaussSeidel(Optimizer):
             p.data.add_(p_y[index : index + p.numel()].reshape(p.shape))
             index += p.numel()
         if index != p_y.numel():
-            raise RuntimeError("CG size mismatch")
+            raise RuntimeError('CG size mismatch')
         return error_real.item(), error_fake.item(), g_error.item()
 
 
@@ -529,8 +542,12 @@ class JacobiMultiCost(Optimizer):
             grad_g_x_vec, self.D.parameters(), grad_g_x_vec, retain_graph=True
         )
 
-        p_x = torch.add(grad_f_x_vec, 2 * D_f_xy).detach_()  # grad_x + 2*D_xy * grad_y
-        p_y = torch.add(grad_g_y_vec, 2 * D_g_yx).detach_()  # grad_y + 2*D_yx * grad_x
+        p_x = torch.add(
+            grad_f_x_vec, 2 * D_f_xy
+        ).detach_()  # grad_x + 2*D_xy * grad_y
+        p_y = torch.add(
+            grad_g_y_vec, 2 * D_g_yx
+        ).detach_()  # grad_y + 2*D_yx * grad_x
         p_x.mul_(self.lr_x)
         p_y.mul_(self.lr_y)
 

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,9 @@
-"""
+'''
 @authors: Vittorio Gabbi (e-mail: vittorio.gabbi@mail.polimi.it)
         : Massimiliano Lupo Pasini (e-mail: lupopasinim@ornl.gov)
         : Nouamane Laanait (e-mail: laanaitn@ornl.gov)
         : Simona Perotto (e-mail: simona.perotto@polimi.it)
-"""
+'''
 ##########################################
 import os
 import numpy as np
@@ -20,42 +20,42 @@ import math
 
 
 def ones_target(size):
-    """
+    '''
     Tensor containing ones, with shape = size
-    """
+    '''
     data = Variable(torch.ones(size, 1))
     return data
 
 
 def ones_target_smooth(size):
-    """
+    '''
     Tensor containing 0.9s, with shape = size
-    """
+    '''
     data = torch.full((size,), 0.9)
     return data
 
 
 def zeros_target(size):
-    """
+    '''
     Tensor containing zeros, with shape = size
-    """
+    '''
     data = Variable(torch.zeros(size, 1))
     return data
 
 
 def zeros_target_smooth(size):
-    """
+    '''
     Tensor containing zeros, with shape = size
-    """
+    '''
     data = torch.full((size,), 0.1)
 
     return data
 
 
 def noise(size, noise_size):
-    """
+    '''
     Generates a 1-d vector of gaussian sampled random values
-    """
+    '''
     n = Variable(torch.randn(size, noise_size))
     return n
 
@@ -66,7 +66,9 @@ def images_to_vectors(images):
 
 
 def vectors_to_images(vectors, array_dim):
-    return vectors.view(vectors.size(0), array_dim[0], array_dim[1], array_dim[2])
+    return vectors.view(
+        vectors.size(0), array_dim[0], array_dim[1], array_dim[2]
+    )
 
 
 def images_to_vectors_cifar10(images):
@@ -98,19 +100,19 @@ def weights_init_normal(m):
 
 def Hvp_vec(grad_vec, params, vec, retain_graph=False):
     if torch.isnan(grad_vec).any():
-        print("grad vec nan")
-        raise ValueError("grad Nan")
+        print('grad vec nan')
+        raise ValueError('grad Nan')
     if torch.isnan(vec).any():
-        print("vec nan")
-        raise ValueError("vec Nan")
+        print('vec nan')
+        raise ValueError('vec Nan')
     try:
         grad_grad = autograd.grad(
             grad_vec, params, grad_outputs=vec, retain_graph=retain_graph
         )
         hvp = torch.cat([g.contiguous().view(-1) for g in grad_grad])
         if torch.isnan(hvp).any():
-            print("hvp nan")
-            raise ValueError("hvp Nan")
+            print('hvp nan')
+            raise ValueError('hvp Nan')
     except:
         # print('filling zero for None')
         grad_grad = autograd.grad(
@@ -128,14 +130,18 @@ def Hvp_vec(grad_vec, params, vec, retain_graph=False):
                 grad_list.append(grad_grad[i].contiguous().view(-1))
         hvp = torch.cat(grad_list)
         if torch.isnan(hvp).any():
-            raise ValueError("hvp Nan")
+            raise ValueError('hvp Nan')
     return hvp
 
 
 def hessian_vec(grad_vec, var, retain_graph=False):
     v = torch.ones_like(var)
     (vec,) = autograd.grad(
-        grad_vec, var, grad_outputs=v, allow_unused=True, retain_graph=retain_graph,
+        grad_vec,
+        var,
+        grad_outputs=v,
+        allow_unused=True,
+        retain_graph=retain_graph,
     )
     return vec
 
@@ -179,7 +185,10 @@ class Richardson(object):
 
         solution = initial_guess
 
-        while relative_residual_norm > self.tol and self.iteration_count < self.maxiter:
+        while (
+            relative_residual_norm > self.tol
+            and self.iteration_count < self.maxiter
+        ):
             ## TODO: consider making all of these non-attributes and just return them
             solution = solution + self.relaxation * residual
 
@@ -192,7 +201,7 @@ class Richardson(object):
                 str(self.iteration_count),
                 " iteration with relative residual norm: ",
                 str(relative_residual_norm),
-                end="...",
+                end='...',
             )
 
         # Do not return because it's already an attribute
@@ -210,9 +219,9 @@ def general_conjugate_gradient(
     x=None,
     nsteps=10,
     residual_tol=1e-16,
-    device=torch.device("cpu"),
+    device=torch.device('cpu'),
 ):
-    """
+    '''
 
     :param grad_x:
     :param grad_y:
@@ -227,11 +236,11 @@ def general_conjugate_gradient(
     :param device:
     :return: (I + sqrt(lr_x) * D_xy * lr_y * D_yx * sqrt(lr_x)) ** -1 * b
 
-    """
+    '''
     if x is None:
         x = torch.zeros(kk.shape[0], device=device)
     if grad_x.shape != kk.shape:
-        raise RuntimeError("CG: hessian vector product shape mismatch")
+        raise RuntimeError('CG: hessian vector product shape mismatch')
     lr_x = lr_x.sqrt()
     mm = kk.clone().detach()
     jj = mm.clone().detach()
@@ -275,9 +284,9 @@ def general_conjugate_gradient_jacobi(
     x=None,
     nsteps=10,
     residual_tol=1e-16,
-    device=torch.device("cpu"),
+    device=torch.device('cpu'),
 ):
-    """
+    '''
 
     :param grad_x:
     :param grad_y:
@@ -292,7 +301,7 @@ def general_conjugate_gradient_jacobi(
     :param device:
     :return: (A) ** -1 * (right_side)
 
-    """
+    '''
     if x is None:
         x = torch.zeros(right_side.shape[0], device=device)
 
@@ -304,7 +313,9 @@ def general_conjugate_gradient_jacobi(
     x_params = tuple(x_params)
 
     for i in range(nsteps):
-        h_1 = Hvp_vec(grad_vec=grad_x, params=x_params, vec=2 * x, retain_graph=True)
+        h_1 = Hvp_vec(
+            grad_vec=grad_x, params=x_params, vec=2 * x, retain_graph=True
+        )
         H = -h_1 + x
         Avp_ = right_side_clone2 + H
 


### PR DESCRIPTION
The formatter in c0d135c58a79a670e9fcc073addda66f88b68296 was run without `-S -l 79` options, thus changing all single quotes into double quotes, and changing line lengths. We want to revert it back.