### PR TITLE
constructors of GANs objects made consistent with abstract class

### DIFF
--- a/CGANs_object.py
+++ b/CGANs_object.py
@@ -33,7 +33,6 @@ class CGANs_MLP_model(GANs_model):
 
     def __init__(self, data, n_classes):
         super(CGANs_MLP_model, self).__init__(data, n_classes)
-        self.n_classes = n_classes
 
     def build_discriminator(self):
         D = ConditionalDiscriminator(self.data_dimension, self.n_classes)

--- a/CNN_CGANs_object.py
+++ b/CNN_CGANs_object.py
@@ -25,7 +25,6 @@ class CNN_CGANs_model(GANs_model):
 
     def __init__(self, data, n_classes):
         super(CNN_CGANs_model, self).__init__(data, n_classes)
-        self.n_classes = n_classes
 
     def build_discriminator(self):
         D = Discriminator_DCC(self.data_dimension, self.n_classes)

--- a/DCGANs_object.py
+++ b/DCGANs_object.py
@@ -28,8 +28,8 @@ from GANs_abstract_object import *
 class DCGANs_model(GANs_model):
     model_name = 'CNN'
 
-    def __init__(self, data):
-        super(DCGANs_model, self).__init__(data)
+    def __init__(self, data, n_classes):
+        super(DCGANs_model, self).__init__(data, n_classes)
 
     def build_discriminator(self):
         D = DiscriminatorCNN(self.data_dimension[0], self.data_dimension[1])

--- a/MLP_GANs_object.py
+++ b/MLP_GANs_object.py
@@ -29,8 +29,8 @@ from GANs_abstract_object import *
 class MLP_GANs_model(GANs_model):
     model_name = 'MLP'
 
-    def __init__(self, data):
-        super(MLP_GANs_model, self).__init__(data)
+    def __init__(self, data, n_classes):
+        super(MLP_GANs_model, self).__init__(data, n_classes)
 
     def build_discriminator(self):
         n_features = numpy.prod(self.data_dimension)

--- a/main_GANs.py
+++ b/main_GANs.py
@@ -120,10 +120,10 @@ if __name__ == '__main__':
 
     if model_switch == 'MLP':
         print("Using MLP implementation of GANs: MLP_GANs_model")
-        model = MLP_GANs_model(cifar100_data())
+        model = MLP_GANs_model(cifar100_data(), 100)
     elif model_switch == 'CNN':
         print("Using CNN implementation of GANs: DCGANs_model")
-        model = DCGANs_model(cifar10_data_dcgans())
+        model = DCGANs_model(cifar10_data_dcgans(), 10)
     elif model_switch == 'C-GANs':
         print("Using conditional GANs implementation with MLP")
         model = CGANs_MLP_model(


### PR DESCRIPTION
There were some inconsistencies between the GANs_abstract_model and the models inheriting from it in terms of constructor signature. Some constructors were taking the number of classes in input, others did not. This apparently was causing the code to crash both on my laptop and on the DGX workstation. 