### PR TITLE
Freezing black to 19.10b0

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black
+        pip install black==19.10b0
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with black
       run: |


### PR DESCRIPTION
It seems that the default version in PIP was upgraded to 20.8b1 which introduced incompatible changes. Have not tested it locally, just creating this PR to see if it fixes it.